### PR TITLE
Add state bootstrap status marker

### DIFF
--- a/cmd/geth/state_bootstrap.go
+++ b/cmd/geth/state_bootstrap.go
@@ -54,6 +54,7 @@ type stateBootstrapConfig struct {
 
 const (
 	stateBootstrapArchiveRoot        = "state-bootstrap"
+	stateBootstrapStatusFilename     = "state-bootstrap.status"
 	stateBootstrapDownloadTimeout    = 2 * time.Hour
 	stateBootstrapDownloadMaxRetries = 3
 	// Release-managed defaults. Update these on each release when bootstrap artifacts rotate.
@@ -104,6 +105,9 @@ func maybeBootstrapState(ctx *cli.Context, stack *node.Node) error {
 	if cfg.filePath == "" && effectiveURL == "" {
 		return nil
 	}
+	statusPath := filepath.Join(stack.InstanceDir(), stateBootstrapStatusFilename)
+	defer removeStateBootstrapStatus(statusPath)
+	writeStateBootstrapStatus(statusPath, "preparing")
 	if usingDefaultURL {
 		log.Info("Using built-in state bootstrap URL", "network", defaultURLNetwork, "url", effectiveURL)
 	}
@@ -118,15 +122,17 @@ func maybeBootstrapState(ctx *cli.Context, stack *node.Node) error {
 	if err != nil {
 		return err
 	}
-	downloadedArchive, err := ensureArchiveAvailable(archivePath, effectiveURL)
+	downloadedArchive, err := ensureArchiveAvailable(archivePath, effectiveURL, statusPath)
 	if err != nil {
 		return err
 	}
 	if effectiveSHA256 != "" {
+		writeStateBootstrapStatus(statusPath, "verifying")
 		if err := verifyArchiveSHA256(archivePath, effectiveSHA256); err != nil {
 			return err
 		}
 	}
+	writeStateBootstrapStatus(statusPath, "installing")
 	if err := installBootstrapArchive(stack.InstanceDir(), chaindataPath, archivePath); err != nil {
 		return err
 	}
@@ -229,11 +235,12 @@ func shouldInstallBootstrap(chaindataPath string, force bool) (bool, error) {
 	return len(entries) == 0, nil
 }
 
-func ensureArchiveAvailable(archivePath, url string) (bool, error) {
+func ensureArchiveAvailable(archivePath, url, statusPath string) (bool, error) {
 	if info, err := os.Stat(archivePath); err == nil {
 		if info.IsDir() {
 			return false, fmt.Errorf("bootstrap archive path points to a directory: %s", archivePath)
 		}
+		writeStateBootstrapStatus(statusPath, "using local archive")
 		return false, nil
 	} else if !os.IsNotExist(err) {
 		return false, fmt.Errorf("stat bootstrap archive: %w", err)
@@ -247,10 +254,29 @@ func ensureArchiveAvailable(archivePath, url string) (bool, error) {
 	}
 
 	log.Info("Downloading state bootstrap archive", "url", url, "path", archivePath)
+	writeStateBootstrapStatus(statusPath, "downloading")
 	if err := downloadBootstrapArchiveWithRetry(archivePath, url); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func writeStateBootstrapStatus(statusPath, phase string) {
+	if statusPath == "" {
+		return
+	}
+	if err := os.WriteFile(statusPath, []byte(strings.TrimSpace(phase)+"\n"), 0o644); err != nil {
+		log.Warn("Failed to write state bootstrap status", "path", statusPath, "phase", phase, "err", err)
+	}
+}
+
+func removeStateBootstrapStatus(statusPath string) {
+	if statusPath == "" {
+		return
+	}
+	if err := os.Remove(statusPath); err != nil && !os.IsNotExist(err) {
+		log.Warn("Failed to remove state bootstrap status", "path", statusPath, "err", err)
+	}
 }
 
 func downloadBootstrapArchiveWithRetry(archivePath, url string) error {

--- a/cmd/geth/state_bootstrap_test.go
+++ b/cmd/geth/state_bootstrap_test.go
@@ -413,7 +413,7 @@ func TestEnsureArchiveAvailable(t *testing.T) {
 		if err := os.WriteFile(archivePath, []byte("existing"), 0o644); err != nil {
 			t.Fatalf("write archive: %v", err)
 		}
-		downloaded, err := ensureArchiveAvailable(archivePath, "https://example.invalid/bootstrap.tar.gz")
+		downloaded, err := ensureArchiveAvailable(archivePath, "https://example.invalid/bootstrap.tar.gz", "")
 		if err != nil {
 			t.Fatalf("ensureArchiveAvailable error: %v", err)
 		}
@@ -424,7 +424,7 @@ func TestEnsureArchiveAvailable(t *testing.T) {
 
 	t.Run("missing without url", func(t *testing.T) {
 		archivePath := filepath.Join(t.TempDir(), "state-bootstrap.tar.gz")
-		downloaded, err := ensureArchiveAvailable(archivePath, "")
+		downloaded, err := ensureArchiveAvailable(archivePath, "", "")
 		if err == nil {
 			t.Fatal("expected error for missing archive without URL")
 		}
@@ -441,7 +441,7 @@ func TestEnsureArchiveAvailable(t *testing.T) {
 		defer server.Close()
 
 		archivePath := filepath.Join(t.TempDir(), "state-bootstrap.tar.gz")
-		downloaded, err := ensureArchiveAvailable(archivePath, server.URL)
+		downloaded, err := ensureArchiveAvailable(archivePath, server.URL, "")
 		if err != nil {
 			t.Fatalf("ensureArchiveAvailable error: %v", err)
 		}
@@ -471,7 +471,7 @@ func TestEnsureArchiveAvailable(t *testing.T) {
 		defer server.Close()
 
 		archivePath := filepath.Join(t.TempDir(), "state-bootstrap.tar.gz")
-		downloaded, err := ensureArchiveAvailable(archivePath, server.URL)
+		downloaded, err := ensureArchiveAvailable(archivePath, server.URL, "")
 		if err != nil {
 			t.Fatalf("ensureArchiveAvailable error: %v", err)
 		}
@@ -577,6 +577,9 @@ func TestMaybeBootstrapStateRemovesDownloadedArchive(t *testing.T) {
 
 	if _, err := os.Stat(downloadPath); !os.IsNotExist(err) {
 		t.Fatalf("expected downloaded archive to be removed after install, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stack.InstanceDir(), stateBootstrapStatusFilename)); !os.IsNotExist(err) {
+		t.Fatalf("expected bootstrap status marker to be removed after install, stat err=%v", err)
 	}
 	installedCurrent := filepath.Join(stack.ResolvePath("chaindata"), "CURRENT")
 	currentData, err := os.ReadFile(installedCurrent)


### PR DESCRIPTION
## Summary
- Write a small state bootstrap status marker while sysgeth prepares, downloads, verifies, and installs bootstrap chaindata.
- Remove the marker once bootstrap import finishes so Syscoin can distinguish active bootstrap work from a stalled startup.
- Cover marker cleanup in the existing state bootstrap test.

## Test plan
- go test ./cmd/geth


Made with [Cursor](https://cursor.com)