### PR TITLE
Harden Syscoin ZMQ REP shutdown handling

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -111,6 +111,7 @@ type Ethereum struct {
 	timeLastBlock     int64
 	stack             *node.Node
 	closeHandler chan struct{}
+	closeHandlerOnce sync.Once
 	blockConnectBuffer []*types.NEVMBlockConnect
 	bufferLock         sync.Mutex
 }
@@ -825,6 +826,11 @@ func (s *Ethereum) setupDiscovery() error {
 // Ethereum protocol.
 func (s *Ethereum) Stop() error {
 	// SYSCOIN
+	if s.closeHandler != nil {
+		s.closeHandlerOnce.Do(func() {
+			close(s.closeHandler)
+		})
+	}
     // Flush buffered blocks first
     if err := s.flushBufferedBlocks(); err != nil {
         log.Error("Failed to flush buffered blocks on shutdown", "err", err)
@@ -853,9 +859,6 @@ func (s *Ethereum) Stop() error {
 	s.wgNEVM.Wait()
 	if s.zmqRep != nil {
 		s.zmqRep.Close()
-	}
-	if s.closeHandler != nil {
-		close(s.closeHandler)
 	}
 	return nil
 }

--- a/eth/zmqpubsub.go
+++ b/eth/zmqpubsub.go
@@ -76,6 +76,10 @@ func (zmq *ZMQRep) InitZMQListener() error {
 				}
 				if len(msg.Frames) != 2 {
 					log.Error("Invalid number of message frames", "len", len(msg.Frames))
+					msgSend := zmq4.NewMsgFrom([]byte("error"), []byte("invalid-message-frames"))
+					if err := zmq.rep.SendMulti(msgSend); err != nil {
+						log.Error("ZMQ send error", "topic", "error", "err", err)
+					}
 					continue
 				}
 				strTopic := string(msg.Frames[0])
@@ -158,6 +162,12 @@ func (zmq *ZMQRep) InitZMQListener() error {
 					if err := zmq.rep.SendMulti(msgSend); err != nil {
 						log.Error("ZMQ send error", "topic", strTopic, "err", err)
 					}	
+				} else {
+					log.Error("Unknown ZMQ request topic", "topic", strTopic)
+					msgSend := zmq4.NewMsgFrom([]byte(strTopic), []byte("unknown-topic"))
+					if err := zmq.rep.SendMulti(msgSend); err != nil {
+						log.Error("ZMQ send error", "topic", strTopic, "err", err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Ensure the Syscoin ZMQ REP listener sends a reply for malformed or unknown request topics so REP state cannot be left waiting.
- Close the Ethereum service `closeHandler` before waiting on Syscoin goroutines, guarded with `sync.Once`, to avoid shutdown hangs or double close risk.

## Test plan
- `go test ./eth -run TestNonExistent`


Made with [Cursor](https://cursor.com)