### PR TITLE
Fix Syscoin NEVM miner txpool readiness

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -421,7 +421,18 @@ func (b *EthAPIBackend) SyncProgress() ethereum.SyncProgress {
 }
 
 func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestTipCap(ctx)
+	// SYSCOIN: keep RPC fee suggestions aligned with the local NEVM miner policy.
+	tip, err := b.gpo.SuggestTipCap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	b.eth.lock.RLock()
+	minTip := new(big.Int).Set(b.eth.gasPrice)
+	b.eth.lock.RUnlock()
+	if tip.Cmp(minTip) < 0 {
+		return minTip, nil
+	}
+	return tip, nil
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, baseFeePerBlobGas []*big.Int, blobGasUsedRatio []float64, err error) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -358,14 +358,17 @@ func (eth *Ethereum) CreateBlock() *types.Block {
 	eth.wgNEVM.Add(1)
 	defer eth.wgNEVM.Done()
 
-	if err := eth.flushBufferedBlocks(); err != nil {
+	inserted, err := eth.flushBufferedBlocks()
+	if err != nil {
 		log.Crit("Failed flushing buffer before createBlock", "err", err)
 		return nil
 	}
-	// SYSCOIN: block insertion is buffered, so force txpool state to catch up before mining.
-	if err := eth.txPool.Sync(); err != nil {
-		log.Error("Failed syncing txpool before createBlock", "err", err)
-		return nil
+	if inserted {
+		// SYSCOIN: block insertion is buffered, so wait for txpool head reset before mining.
+		if err := eth.txPool.Sync(); err != nil {
+			log.Error("Failed syncing txpool before createBlock", "err", err)
+			return nil
+		}
 	}
 
 	return eth.miner.GenerateWorkSyscoin(
@@ -462,16 +465,17 @@ func (eth *Ethereum) AddBlock(nevmBlockConnectIn *types.NEVMBlockConnect) error 
         return nil
     }
 
-    return eth.flushBufferedBlocks()
+    _, err := eth.flushBufferedBlocks()
+    return err
 }
 
 
-func (eth *Ethereum) flushBufferedBlocks() error {
+func (eth *Ethereum) flushBufferedBlocks() (bool, error) {
     eth.bufferLock.Lock()
     defer eth.bufferLock.Unlock()
 
     if len(eth.blockConnectBuffer) == 0 {
-        return nil
+        return false, nil
     }
 
     blockBuffer := make([]*types.Block, 0, len(eth.blockConnectBuffer))
@@ -481,11 +485,11 @@ func (eth *Ethereum) flushBufferedBlocks() error {
     }
 
     if _, err := eth.blockchain.InsertChain(blockBuffer); err != nil {
-        return err
+        return false, err
     }
 
     eth.blockConnectBuffer = eth.blockConnectBuffer[:0] // safely clear buffer
-    return nil
+    return true, nil
 }
 
 func (eth *Ethereum) disconnectBufferedBlock(blockHash common.Hash) (bool, error) {
@@ -837,7 +841,7 @@ func (s *Ethereum) Stop() error {
 		})
 	}
     // Flush buffered blocks first
-    if err := s.flushBufferedBlocks(); err != nil {
+    if _, err := s.flushBufferedBlocks(); err != nil {
         log.Error("Failed to flush buffered blocks on shutdown", "err", err)
     }
 	// Stop all the peer-related stuff first.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -362,6 +362,11 @@ func (eth *Ethereum) CreateBlock() *types.Block {
 		log.Crit("Failed flushing buffer before createBlock", "err", err)
 		return nil
 	}
+	// SYSCOIN: block insertion is buffered, so force txpool state to catch up before mining.
+	if err := eth.txPool.Sync(); err != nil {
+		log.Error("Failed syncing txpool before createBlock", "err", err)
+		return nil
+	}
 
 	return eth.miner.GenerateWorkSyscoin(
 		eth.config.Miner.Etherbase,


### PR DESCRIPTION
## Summary
- Force txpool state to catch up after buffered Syscoin NEVM block inserts before building the next block.
- Clamp RPC gas tip suggestions to the local miner minimum so suggested fees are locally mineable.

## Test plan
- go test ./eth ./miner

Made with [Cursor](https://cursor.com)