### PR TITLE
Floor Syscoin fee history rewards to miner tip

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -436,7 +436,22 @@ func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) 
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, baseFeePerBlobGas []*big.Int, blobGasUsedRatio []float64, err error) {
-	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
+	// SYSCOIN: keep feeHistory rewards aligned with the local NEVM miner policy.
+	firstBlock, reward, baseFee, gasUsedRatio, baseFeePerBlobGas, blobGasUsedRatio, err = b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
+	if err != nil || reward == nil {
+		return firstBlock, reward, baseFee, gasUsedRatio, baseFeePerBlobGas, blobGasUsedRatio, err
+	}
+	b.eth.lock.RLock()
+	minTip := new(big.Int).Set(b.eth.gasPrice)
+	b.eth.lock.RUnlock()
+	for i := range reward {
+		for j, tip := range reward[i] {
+			if tip == nil || tip.Cmp(minTip) < 0 {
+				reward[i][j] = new(big.Int).Set(minTip)
+			}
+		}
+	}
+	return firstBlock, reward, baseFee, gasUsedRatio, baseFeePerBlobGas, blobGasUsedRatio, nil
 }
 
 func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) *big.Int {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -444,14 +444,18 @@ func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastB
 	b.eth.lock.RLock()
 	minTip := new(big.Int).Set(b.eth.gasPrice)
 	b.eth.lock.RUnlock()
-	for i := range reward {
-		for j, tip := range reward[i] {
+	flooredReward := make([][]*big.Int, len(reward))
+	for i, tips := range reward {
+		flooredReward[i] = make([]*big.Int, len(tips))
+		for j, tip := range tips {
 			if tip == nil || tip.Cmp(minTip) < 0 {
-				reward[i][j] = new(big.Int).Set(minTip)
+				flooredReward[i][j] = new(big.Int).Set(minTip)
+			} else {
+				flooredReward[i][j] = new(big.Int).Set(tip)
 			}
 		}
 	}
-	return firstBlock, reward, baseFee, gasUsedRatio, baseFeePerBlobGas, blobGasUsedRatio, nil
+	return firstBlock, flooredReward, baseFee, gasUsedRatio, baseFeePerBlobGas, blobGasUsedRatio, nil
 }
 
 func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) *big.Int {


### PR DESCRIPTION
## Summary
- Floor `eth_feeHistory` reward entries to the local NEVM miner minimum tip.
- Prevent feeHistory-based EIP-1559 estimators from choosing 1 wei tips after empty blocks.

## Test plan
- go test ./eth

Made with [Cursor](https://cursor.com)