### PR TITLE
Fix Syscoin legacy gas price headroom

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -426,13 +426,18 @@ func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) 
 	if err != nil {
 		return nil, err
 	}
-	b.eth.lock.RLock()
-	minTip := new(big.Int).Set(b.eth.gasPrice)
-	b.eth.lock.RUnlock()
+	minTip := b.MinerGasTipFloor()
 	if tip.Cmp(minTip) < 0 {
 		return minTip, nil
 	}
 	return tip, nil
+}
+
+func (b *EthAPIBackend) MinerGasTipFloor() *big.Int {
+	// SYSCOIN: this is the local NEVM miner tip floor used by tx selection.
+	b.eth.lock.RLock()
+	defer b.eth.lock.RUnlock()
+	return new(big.Int).Set(b.eth.gasPrice)
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, baseFeePerBlobGas []*big.Int, blobGasUsedRatio []float64, err error) {
@@ -441,9 +446,7 @@ func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastB
 	if err != nil || reward == nil {
 		return firstBlock, reward, baseFee, gasUsedRatio, baseFeePerBlobGas, blobGasUsedRatio, err
 	}
-	b.eth.lock.RLock()
-	minTip := new(big.Int).Set(b.eth.gasPrice)
-	b.eth.lock.RUnlock()
+	minTip := b.MinerGasTipFloor()
 	flooredReward := make([][]*big.Int, len(reward))
 	for i, tips := range reward {
 		flooredReward[i] = make([]*big.Int, len(tips))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -358,17 +358,14 @@ func (eth *Ethereum) CreateBlock() *types.Block {
 	eth.wgNEVM.Add(1)
 	defer eth.wgNEVM.Done()
 
-	inserted, err := eth.flushBufferedBlocks()
-	if err != nil {
+	if err := eth.flushBufferedBlocks(); err != nil {
 		log.Crit("Failed flushing buffer before createBlock", "err", err)
 		return nil
 	}
-	if inserted {
-		// SYSCOIN: block insertion is buffered, so wait for txpool head reset before mining.
-		if err := eth.txPool.Sync(); err != nil {
-			log.Error("Failed syncing txpool before createBlock", "err", err)
-			return nil
-		}
+	// SYSCOIN: block insertion is buffered, so force txpool state to catch up before mining.
+	if err := eth.txPool.Sync(); err != nil {
+		log.Error("Failed syncing txpool before createBlock", "err", err)
+		return nil
 	}
 
 	return eth.miner.GenerateWorkSyscoin(
@@ -465,17 +462,16 @@ func (eth *Ethereum) AddBlock(nevmBlockConnectIn *types.NEVMBlockConnect) error 
         return nil
     }
 
-    _, err := eth.flushBufferedBlocks()
-    return err
+    return eth.flushBufferedBlocks()
 }
 
 
-func (eth *Ethereum) flushBufferedBlocks() (bool, error) {
+func (eth *Ethereum) flushBufferedBlocks() error {
     eth.bufferLock.Lock()
     defer eth.bufferLock.Unlock()
 
     if len(eth.blockConnectBuffer) == 0 {
-        return false, nil
+        return nil
     }
 
     blockBuffer := make([]*types.Block, 0, len(eth.blockConnectBuffer))
@@ -485,11 +481,11 @@ func (eth *Ethereum) flushBufferedBlocks() (bool, error) {
     }
 
     if _, err := eth.blockchain.InsertChain(blockBuffer); err != nil {
-        return false, err
+        return err
     }
 
     eth.blockConnectBuffer = eth.blockConnectBuffer[:0] // safely clear buffer
-    return true, nil
+    return nil
 }
 
 func (eth *Ethereum) disconnectBufferedBlock(blockHash common.Hash) (bool, error) {
@@ -841,7 +837,7 @@ func (s *Ethereum) Stop() error {
 		})
 	}
     // Flush buffered blocks first
-    if _, err := s.flushBufferedBlocks(); err != nil {
+    if err := s.flushBufferedBlocks(); err != nil {
         log.Error("Failed to flush buffered blocks on shutdown", "err", err)
     }
 	// Stop all the peer-related stuff first.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -362,11 +362,6 @@ func (eth *Ethereum) CreateBlock() *types.Block {
 		log.Crit("Failed flushing buffer before createBlock", "err", err)
 		return nil
 	}
-	// SYSCOIN: block insertion is buffered, so force txpool state to catch up before mining.
-	if err := eth.txPool.Sync(); err != nil {
-		log.Error("Failed syncing txpool before createBlock", "err", err)
-		return nil
-	}
 
 	return eth.miner.GenerateWorkSyscoin(
 		eth.config.Miner.Etherbase,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -72,9 +72,29 @@ func (api *EthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 		return nil, err
 	}
 	if head := api.b.CurrentHeader(); head.BaseFee != nil {
-		tipcap.Add(tipcap, head.BaseFee)
+		tipcap = legacyGasPriceWithSyscoinFloorHeadroom(api.b.ChainConfig(), head, tipcap, api.b.MinerGasTipFloor())
 	}
 	return (*hexutil.Big)(tipcap), err
+}
+
+func legacyGasPriceWithSyscoinFloorHeadroom(config *params.ChainConfig, head *types.Header, tipcap, minTip *big.Int) *big.Int {
+	baseFee := head.BaseFee
+	if config.IsSyscoin(head.Number) && tipcap.Cmp(minTip) == 0 && baseFee.Cmp(minTip) < 0 {
+		// SYSCOIN: legacy eth_gasPrice callers such as Foundry --legacy need
+		// low-base-fee headroom. Treat the miner tip floor as the base-fee floor
+		// for this suggestion, so large same-price batches do not flip below the
+		// miner floor as base fee walks up from tiny testnet values.
+		baseFee = syscoinNextBaseFeeFromFloor(config, minTip)
+	}
+	return new(big.Int).Add(tipcap, baseFee)
+}
+
+func syscoinNextBaseFeeFromFloor(config *params.ChainConfig, floor *big.Int) *big.Int {
+	change := new(big.Int).Div(floor, new(big.Int).SetUint64(config.BaseFeeChangeDenominator()))
+	if change.Cmp(common.Big1) < 0 {
+		change = common.Big1
+	}
+	return new(big.Int).Add(floor, change)
 }
 
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -62,6 +62,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLegacyGasPriceWithSyscoinFloorHeadroom(t *testing.T) {
+	syscoinConfig := *params.TanenbaumChainConfig
+	mainnetConfig := *params.MainnetChainConfig
+	minTip := big.NewInt(10_000)
+
+	tests := []struct {
+		name   string
+		config *params.ChainConfig
+		base   int64
+		tip    int64
+		want   int64
+	}{
+		{
+			name:   "syscoin floor tip gets floor-derived low base fee headroom",
+			config: &syscoinConfig,
+			base:   7,
+			tip:    10_000,
+			want:   21_250,
+		},
+		{
+			name:   "syscoin above-floor tip is not inflated",
+			config: &syscoinConfig,
+			base:   7,
+			tip:    10_020,
+			want:   10_027,
+		},
+		{
+			name:   "syscoin at-floor base fee floor tip is not inflated",
+			config: &syscoinConfig,
+			base:   10_000,
+			tip:    10_000,
+			want:   20_000,
+		},
+		{
+			name:   "syscoin high base fee floor tip is not inflated",
+			config: &syscoinConfig,
+			base:   20_000,
+			tip:    10_000,
+			want:   30_000,
+		},
+		{
+			name:   "non-syscoin keeps upstream legacy gas price behavior",
+			config: &mainnetConfig,
+			base:   7,
+			tip:    10_000,
+			want:   10_007,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			head := &types.Header{Number: big.NewInt(1), BaseFee: big.NewInt(test.base)}
+			got := legacyGasPriceWithSyscoinFloorHeadroom(test.config, head, big.NewInt(test.tip), minTip)
+			require.Equal(t, big.NewInt(test.want), got)
+		})
+	}
+}
+
 func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainConfig) {
 	var (
 		signer = types.LatestSigner(config)
@@ -476,6 +534,7 @@ func (b testBackend) SyncProgress() ethereum.SyncProgress { return ethereum.Sync
 func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(0), nil
 }
+func (b testBackend) MinerGasTipFloor() *big.Int { return big.NewInt(0) }
 func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil, nil, nil
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -44,6 +44,9 @@ type Backend interface {
 	SyncProgress() ethereum.SyncProgress
 
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+	// SYSCOIN: exposes the local miner tip floor so legacy gas-price suggestions
+	// can avoid pricing transactions exactly at the floor in low-base-fee regimes.
+	MinerGasTipFloor() *big.Int
 	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
 	BlobBaseFee(ctx context.Context) *big.Int
 	ChainDb() ethdb.Database

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -317,6 +317,7 @@ func (b *backendMock) setFork(fork string) error {
 func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }
+func (b *backendMock) MinerGasTipFloor() *big.Int               { return big.NewInt(0) }
 func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int { return big.NewInt(42) }
 
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }


### PR DESCRIPTION
## Summary
- Add Syscoin-specific legacy `eth_gasPrice` headroom when the suggested tip is exactly the local miner floor and base fees are still below that floor.
- Keep `eth_maxPriorityFeePerGas` floored to the miner tip without inflating dynamic-fee priority tips.
- Remove the txpool sync path before Syscoin block creation; the observed alternating empty blocks were caused by floor-priced legacy txs becoming underpriced as base fee rose, not txpool readiness.

## Test plan
- `go test ./internal/ethapi -run TestLegacyGasPriceWithSyscoinFloorHeadroom`
- `git diff --check`

Made with [Cursor](https://cursor.com)