### PR TITLE
Add Liberty fork for Syscoin opcode activation

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -109,8 +109,9 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	case evm.chainRules.IsVerkle:
 		// TODO replace with proper instruction set when fork is specified
 		table = &verkleInstructionSet
-	case evm.chainRules.IsNexus:
-		table = &nexusInstructionSet
+	// SYSCOIN
+	case evm.chainRules.IsLiberty:
+		table = &libertyInstructionSet
 	case evm.chainRules.IsPrague:
 		table = &pragueInstructionSet
 	case evm.chainRules.IsCancun:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -59,11 +59,12 @@ var (
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
-	nexusInstructionSet            = newNexusInstructionSet()
-	cancunInstructionSet           = newCancunInstructionSet()
-	verkleInstructionSet           = newVerkleInstructionSet()
-	pragueInstructionSet           = newPragueInstructionSet()
-	eofInstructionSet              = newEOFInstructionSetForTesting()
+	// SYSCOIN
+	libertyInstructionSet = newLibertyInstructionSet()
+	cancunInstructionSet  = newCancunInstructionSet()
+	verkleInstructionSet  = newVerkleInstructionSet()
+	pragueInstructionSet  = newPragueInstructionSet()
+	eofInstructionSet     = newEOFInstructionSetForTesting()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -109,8 +110,9 @@ func newPragueInstructionSet() JumpTable {
 	return validate(instructionSet)
 }
 
-func newNexusInstructionSet() JumpTable {
-	// SYSCOIN: enable MCOPY and transient storage opcodes at Nexus without
+// SYSCOIN
+func newLibertyInstructionSet() JumpTable {
+	// SYSCOIN: enable MCOPY and transient storage opcodes at Liberty without
 	// enabling the full Cancun instruction set (e.g. blob opcodes/signer paths).
 	instructionSet := newShanghaiInstructionSet()
 	enable1153(&instructionSet) // EIP-1153 "Transient Storage"

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -34,8 +34,9 @@ func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
 		return newPragueInstructionSet(), nil
 	case rules.IsCancun:
 		return newCancunInstructionSet(), nil
-	case rules.IsNexus:
-		return newNexusInstructionSet(), nil
+	// SYSCOIN
+	case rules.IsLiberty:
+		return newLibertyInstructionSet(), nil
 	case rules.IsShanghai:
 		return newShanghaiInstructionSet(), nil
 	case rules.IsMerge:

--- a/core/vm/jump_table_test.go
+++ b/core/vm/jump_table_test.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,14 +35,25 @@ func TestJumpTableCopy(t *testing.T) {
 	require.Equal(t, uint64(0), tbl[SLOAD].constantGas)
 }
 
-func TestNexusInstructionSetEnablesOnlyTransientAndMcopy(t *testing.T) {
-	tbl := newNexusInstructionSet()
+// SYSCOIN
+func TestLibertyInstructionSetEnablesOnlyTransientAndMcopy(t *testing.T) {
+	tbl := newLibertyInstructionSet()
 
-	require.True(t, tbl[TLOAD].HasCost(), "TLOAD must be enabled at Nexus")
-	require.True(t, tbl[TSTORE].HasCost(), "TSTORE must be enabled at Nexus")
-	require.True(t, tbl[MCOPY].HasCost(), "MCOPY must be enabled at Nexus")
+	require.True(t, tbl[TLOAD].HasCost(), "TLOAD must be enabled at Liberty")
+	require.True(t, tbl[TSTORE].HasCost(), "TSTORE must be enabled at Liberty")
+	require.True(t, tbl[MCOPY].HasCost(), "MCOPY must be enabled at Liberty")
 
-	// Keep Cancun blob opcodes disabled for Nexus-only activation.
-	require.False(t, tbl[BLOBHASH].HasCost(), "BLOBHASH must remain disabled at Nexus")
-	require.False(t, tbl[BLOBBASEFEE].HasCost(), "BLOBBASEFEE must remain disabled at Nexus")
+	// Keep Cancun blob opcodes disabled for Liberty-only activation.
+	require.False(t, tbl[BLOBHASH].HasCost(), "BLOBHASH must remain disabled at Liberty")
+	require.False(t, tbl[BLOBBASEFEE].HasCost(), "BLOBBASEFEE must remain disabled at Liberty")
+}
+
+// SYSCOIN
+func TestNexusInstructionSetDoesNotEnableLibertyOpcodes(t *testing.T) {
+	tbl, err := LookupInstructionSet(params.Rules{IsNexus: true, IsShanghai: true})
+	require.NoError(t, err)
+
+	require.False(t, tbl[TLOAD].HasCost(), "TLOAD must remain disabled before Liberty")
+	require.False(t, tbl[TSTORE].HasCost(), "TSTORE must remain disabled before Liberty")
+	require.False(t, tbl[MCOPY].HasCost(), "MCOPY must remain disabled before Liberty")
 }

--- a/params/config.go
+++ b/params/config.go
@@ -30,11 +30,11 @@ import (
 var (
 	MainnetGenesisHash = common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
 	// SYSCOIN
-	SyscoinGenesisHash = common.HexToHash("0x2112327cad6deec6ada8bd7e5d33d263b57742a8495f3b641faa326b55b1c666")
+	SyscoinGenesisHash   = common.HexToHash("0x2112327cad6deec6ada8bd7e5d33d263b57742a8495f3b641faa326b55b1c666")
 	TanenbaumGenesisHash = common.HexToHash("0x5fb22cd4425cea75d2ddaf5fbafb247bb682f407575c599d954b811214c3617c")
-	HoleskyGenesisHash = common.HexToHash("0xb5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4")
-	SepoliaGenesisHash = common.HexToHash("0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9")
-	HoodiGenesisHash   = common.HexToHash("0xbbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b")
+	HoleskyGenesisHash   = common.HexToHash("0xb5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4")
+	SepoliaGenesisHash   = common.HexToHash("0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9")
+	HoodiGenesisHash     = common.HexToHash("0xbbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b")
 )
 
 func newUint64(val uint64) *uint64 { return &val }
@@ -73,30 +73,31 @@ var (
 	}
 	// SYSCOIN
 	SyscoinChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(57),
-		HomesteadBlock:      big.NewInt(0),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      false,
-		EIP150Block:         big.NewInt(0),
-		EIP155Block:         big.NewInt(0),
-		EIP158Block:         big.NewInt(0),
-		ByzantiumBlock:      big.NewInt(0),
-		ConstantinopleBlock: big.NewInt(0),
-		PetersburgBlock:     big.NewInt(0),
-		IstanbulBlock:       big.NewInt(0),
-		MuirGlacierBlock:    big.NewInt(0),
-		BerlinBlock:         big.NewInt(0),
-		SyscoinBlock:        big.NewInt(0),
-		RolluxBlock:         big.NewInt(268500),
-		ShanghaiBlock:       big.NewInt(268500),
-		NexusBlock:          big.NewInt(692846),
-		LondonBlock:         big.NewInt(1),
+		ChainID:                 big.NewInt(57),
+		HomesteadBlock:          big.NewInt(0),
+		DAOForkBlock:            nil,
+		DAOForkSupport:          false,
+		EIP150Block:             big.NewInt(0),
+		EIP155Block:             big.NewInt(0),
+		EIP158Block:             big.NewInt(0),
+		ByzantiumBlock:          big.NewInt(0),
+		ConstantinopleBlock:     big.NewInt(0),
+		PetersburgBlock:         big.NewInt(0),
+		IstanbulBlock:           big.NewInt(0),
+		MuirGlacierBlock:        big.NewInt(0),
+		BerlinBlock:             big.NewInt(0),
+		SyscoinBlock:            big.NewInt(0),
+		RolluxBlock:             big.NewInt(268500),
+		ShanghaiBlock:           big.NewInt(268500),
+		NexusBlock:              big.NewInt(692846),
+		LibertyBlock:            nil,
+		LondonBlock:             big.NewInt(1),
 		TerminalTotalDifficulty: big.NewInt(1),
 		//ShanghaiTime:                  newUint64(1679618404),
 		// SYSCOIN TODO enable later fork such as prague or verkle (make sure to merge which instruction sets into latest one for us)
 		// cancun enables a new signer so we jump to prague or better to ensure we dont need blob signing txs from cancun
 		//CancunTime:                    newUint64(1679618404),
-		Ethash:              nil,
+		Ethash: nil,
 	}
 	TanenbaumChainConfig = &ChainConfig{
 		ChainID:             big.NewInt(5700),
@@ -116,11 +117,12 @@ var (
 		RolluxBlock:         big.NewInt(182500),
 		ShanghaiBlock:       big.NewInt(223000),
 		//ShanghaiTime:        newUint64(1675118284),
-		NexusBlock:          big.NewInt(665001),
-		LondonBlock:         big.NewInt(1),
+		NexusBlock:   big.NewInt(665001),
+		LibertyBlock: big.NewInt(906001),
+		LondonBlock:  big.NewInt(1),
 		//CancunTime:          newUint64(1675118284),
 		TerminalTotalDifficulty: big.NewInt(1),
-		Ethash:              nil,
+		Ethash:                  nil,
 	}
 	// HoleskyChainConfig contains the chain parameters to run a node on the Holesky test network.
 	HoleskyChainConfig = &ChainConfig{
@@ -424,11 +426,11 @@ var (
 var NetworkNames = map[string]string{
 	MainnetChainConfig.ChainID.String(): "mainnet",
 	// SYSCOIN
-	SyscoinChainConfig.ChainID.String(): "syscoin",
+	SyscoinChainConfig.ChainID.String():   "syscoin",
 	TanenbaumChainConfig.ChainID.String(): "tanenbaum",
-	SepoliaChainConfig.ChainID.String(): "sepolia",
-	HoleskyChainConfig.ChainID.String(): "holesky",
-	HoodiChainConfig.ChainID.String():   "hoodi",
+	SepoliaChainConfig.ChainID.String():   "sepolia",
+	HoleskyChainConfig.ChainID.String():   "holesky",
+	HoodiChainConfig.ChainID.String():     "hoodi",
 }
 
 // ChainConfig is the core config which determines the blockchain settings.
@@ -460,10 +462,11 @@ type ChainConfig struct {
 	GrayGlacierBlock    *big.Int `json:"grayGlacierBlock,omitempty"`    // Eip-5133 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	MergeNetsplitBlock  *big.Int `json:"mergeNetsplitBlock,omitempty"`  // Virtual fork after The Merge to use as a network splitter
 	// SYSCOIN
-	SyscoinBlock        *big.Int `json:"syscoinBlock,omitempty"`        // Syscoin switch block (nil = no fork, 0 = already on syscoin)
-	RolluxBlock         *big.Int `json:"rolluxBlock,omitempty"`         // Rollux switch block (nil = no fork, 0 = already on syscoin)
-	ShanghaiBlock       *big.Int `json:"shanghaiBlock,omitempty"`       // Rollux switch block (nil = no fork, 0 = already on syscoin)
-	NexusBlock          *big.Int `json:"nexusBlock,omitempty"`          // Nexus switch block (nil = no fork, 0 = already on syscoin)
+	SyscoinBlock  *big.Int `json:"syscoinBlock,omitempty"`  // Syscoin switch block (nil = no fork, 0 = already on syscoin)
+	RolluxBlock   *big.Int `json:"rolluxBlock,omitempty"`   // Rollux switch block (nil = no fork, 0 = already on syscoin)
+	ShanghaiBlock *big.Int `json:"shanghaiBlock,omitempty"` // Rollux switch block (nil = no fork, 0 = already on syscoin)
+	NexusBlock    *big.Int `json:"nexusBlock,omitempty"`    // Nexus switch block (nil = no fork, 0 = already on syscoin)
+	LibertyBlock  *big.Int `json:"libertyBlock,omitempty"`  // Liberty opcode switch block (nil = no fork, 0 = already on syscoin)
 	// Fork scheduling was switched from blocks to timestamps here
 
 	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty"` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
@@ -691,6 +694,7 @@ func (c *ChainConfig) IsTerminalPoWBlock(parentTotalDiff *big.Int, totalDiff *bi
 	}
 	return parentTotalDiff.Cmp(c.TerminalTotalDifficulty) < 0 && totalDiff.Cmp(c.TerminalTotalDifficulty) >= 0
 }
+
 // SYSCOIN IsSyscoin returns whether num is either equal to the Syscoin fork block or greater.
 func (c *ChainConfig) IsSyscoin(num *big.Int) bool {
 	return isBlockForked(c.SyscoinBlock, num)
@@ -701,6 +705,12 @@ func (c *ChainConfig) IsRollux(num *big.Int) bool {
 func (c *ChainConfig) IsNexus(num *big.Int) bool {
 	return isBlockForked(c.NexusBlock, num)
 }
+
+// SYSCOIN
+func (c *ChainConfig) IsLiberty(num *big.Int) bool {
+	return isBlockForked(c.LibertyBlock, num)
+}
+
 // IsShanghai returns whether time is either equal to the Shanghai fork time or greater.
 func (c *ChainConfig) IsShanghai(num *big.Int, time uint64) bool {
 	// SYSCOIN
@@ -948,6 +958,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	if isForkBlockIncompatible(c.NexusBlock, newcfg.NexusBlock, headNumber) {
 		return newBlockCompatError("Nexus fork block", c.NexusBlock, newcfg.NexusBlock)
 	}
+	if isForkBlockIncompatible(c.LibertyBlock, newcfg.LibertyBlock, headNumber) {
+		return newBlockCompatError("Liberty fork block", c.LibertyBlock, newcfg.LibertyBlock)
+	}
 	if isForkTimestampIncompatible(c.ShanghaiTime, newcfg.ShanghaiTime, headTimestamp) {
 		return newTimestampCompatError("Shanghai fork timestamp", c.ShanghaiTime, newcfg.ShanghaiTime)
 	}
@@ -1151,9 +1164,9 @@ type Rules struct {
 	IsEIP2929, IsEIP4762                                    bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	// SYSCOIN
-	IsBerlin, IsLondon, IsSyscoin, IsRollux, IsNexus        bool
-	IsMerge, IsShanghai, IsCancun, IsPrague, IsOsaka        bool
-	IsVerkle                                                bool
+	IsBerlin, IsLondon, IsSyscoin, IsRollux, IsNexus, IsLiberty bool
+	IsMerge, IsShanghai, IsCancun, IsPrague, IsOsaka            bool
+	IsVerkle                                                    bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1180,15 +1193,16 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
 		// SYSCOIN
-		IsShanghai:       c.IsShanghai(num, timestamp),
-		IsCancun:         isMerge && c.IsCancun(num, timestamp),
-		IsPrague:         isMerge && c.IsPrague(num, timestamp),
-		IsOsaka:          isMerge && c.IsOsaka(num, timestamp),
-		IsVerkle:         isVerkle,
-		IsEIP4762:        isVerkle,
+		IsShanghai: c.IsShanghai(num, timestamp),
+		IsCancun:   isMerge && c.IsCancun(num, timestamp),
+		IsPrague:   isMerge && c.IsPrague(num, timestamp),
+		IsOsaka:    isMerge && c.IsOsaka(num, timestamp),
+		IsVerkle:   isVerkle,
+		IsEIP4762:  isVerkle,
 		// SYSCOIN
-		IsSyscoin:        c.IsSyscoin(num),
-		IsRollux:         c.IsRollux(num),
-		IsNexus:          c.IsNexus(num),
+		IsSyscoin: c.IsSyscoin(num),
+		IsRollux:  c.IsRollux(num),
+		IsNexus:   c.IsNexus(num),
+		IsLiberty: c.IsLiberty(num),
 	}
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -110,6 +110,24 @@ func TestCheckCompatible(t *testing.T) {
 				RewindToTime: 9,
 			},
 		},
+		// SYSCOIN
+		{
+			stored:    &ChainConfig{LibertyBlock: big.NewInt(100)},
+			new:       &ChainConfig{LibertyBlock: big.NewInt(200)},
+			headBlock: 99,
+			wantErr:   nil,
+		},
+		{
+			stored:    &ChainConfig{LibertyBlock: big.NewInt(100)},
+			new:       &ChainConfig{LibertyBlock: big.NewInt(200)},
+			headBlock: 150,
+			wantErr: &ConfigCompatError{
+				What:          "Liberty fork block",
+				StoredBlock:   big.NewInt(100),
+				NewBlock:      big.NewInt(200),
+				RewindToBlock: 99,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -136,6 +154,18 @@ func TestConfigRules(t *testing.T) {
 	stamp = math.MaxInt64
 	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsShanghai {
 		t.Errorf("expected %v to be shanghai", stamp)
+	}
+
+	// SYSCOIN
+	c = &ChainConfig{
+		NexusBlock:   big.NewInt(10),
+		LibertyBlock: big.NewInt(20),
+	}
+	if r := c.Rules(big.NewInt(15), true, 0); !r.IsNexus || r.IsLiberty {
+		t.Errorf("expected block 15 to be nexus-only")
+	}
+	if r := c.Rules(big.NewInt(20), true, 0); !r.IsNexus || !r.IsLiberty {
+		t.Errorf("expected block 20 to be liberty")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a Syscoin Liberty fork block and rule alongside Nexus.
- Moves the MCOPY/transient-storage opcode bundle from Nexus to Liberty so historical Tanenbaum Nexus blocks keep their prior VM semantics.
- Adds focused tests for Liberty compatibility checks and opcode activation.

## Test plan
- go test ./params ./core/vm


Made with [Cursor](https://cursor.com)