### PR TITLE
Fix eth_simulateV1 Syscoin precompile readers

### DIFF
--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -687,7 +687,7 @@ func (b testBackend) NewMatcherBackend() filtermaps.MatcherBackend {
 
 // SYSCOIN
 func (b testBackend) ReadSYSHash(ctx context.Context, number rpc.BlockNumber) ([]byte, error) {
-	return []byte{}, nil
+	return common.BigToHash(big.NewInt(int64(number))).Bytes(), nil
 }
 func (b testBackend) BTCCheckpointIndex(ctx context.Context, hash common.Hash) (uint64, error) {
 	return 7, nil
@@ -699,22 +699,34 @@ func (b testBackend) ReadBTCCheckpointHashByIndex(ctx context.Context, idx uint6
 	return common.BigToHash(big.NewInt(int64(idx))).Bytes(), nil
 }
 func (b testBackend) ReadDataHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	return []byte{}, nil
+	return hash.Bytes(), nil
 }
 func (b testBackend) GetNEVMAddress(ctx context.Context, address common.Address) ([]byte, error) {
-	return []byte{}, nil
+	return address.Bytes(), nil
 }
 func (b testBackend) HistoryPruningCutoff() uint64 {
 	bn, _ := b.chain.HistoryPruningCutoff()
 	return bn
 }
 
-func TestChainContextBTCCheckpointReaders(t *testing.T) {
+func TestChainContextSyscoinReaders(t *testing.T) {
 	t.Parallel()
 
 	backend := testBackend{}
 	ctx := NewChainContext(context.Background(), backend)
 	hash := common.HexToHash("0x1234")
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	wantSYSHash := common.BigToHash(big.NewInt(11)).Bytes()
+	if got := ctx.ReadSYSHash(11); !bytes.Equal(got, wantSYSHash) {
+		t.Fatalf("unexpected SYS hash bytes: got %x want %x", got, wantSYSHash)
+	}
+	if got := ctx.ReadDataHash(hash); !bytes.Equal(got, hash.Bytes()) {
+		t.Fatalf("unexpected data hash bytes: got %x want %x", got, hash.Bytes())
+	}
+	if got := ctx.GetNEVMAddress(address); !bytes.Equal(got, address.Bytes()) {
+		t.Fatalf("unexpected NEVM address bytes: got %x want %x", got, address.Bytes())
+	}
 
 	if got := ctx.BTCCheckpointIndex(hash); got != 7 {
 		t.Fatalf("unexpected checkpoint index: got %d want %d", got, 7)
@@ -725,6 +737,37 @@ func TestChainContextBTCCheckpointReaders(t *testing.T) {
 	wantHash := common.BigToHash(big.NewInt(5)).Bytes()
 	if got := ctx.ReadBTCCheckpointHashByIndex(5); !bytes.Equal(got, wantHash) {
 		t.Fatalf("unexpected checkpoint hash bytes: got %x want %x", got, wantHash)
+	}
+}
+
+func TestSimBackendSyscoinReadersDelegate(t *testing.T) {
+	t.Parallel()
+
+	backend := testBackend{}
+	sim := &simBackend{b: backend}
+	ctx := context.Background()
+	hash := common.HexToHash("0x5678")
+	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	wantSYSHash := common.BigToHash(big.NewInt(12)).Bytes()
+	if got, err := sim.ReadSYSHash(ctx, 12); err != nil || !bytes.Equal(got, wantSYSHash) {
+		t.Fatalf("unexpected simulated SYS hash: got %x err %v want %x", got, err, wantSYSHash)
+	}
+	if got, err := sim.ReadDataHash(ctx, hash); err != nil || !bytes.Equal(got, hash.Bytes()) {
+		t.Fatalf("unexpected simulated data hash: got %x err %v want %x", got, err, hash.Bytes())
+	}
+	if got, err := sim.GetNEVMAddress(ctx, address); err != nil || !bytes.Equal(got, address.Bytes()) {
+		t.Fatalf("unexpected simulated NEVM address: got %x err %v want %x", got, err, address.Bytes())
+	}
+	if got, err := sim.BTCCheckpointIndex(ctx, hash); err != nil || got != 7 {
+		t.Fatalf("unexpected simulated checkpoint index: got %d err %v want %d", got, err, 7)
+	}
+	if got, err := sim.ReadBTCCheckpointLastIndex(ctx); err != nil || got != 9 {
+		t.Fatalf("unexpected simulated last checkpoint index: got %d err %v want %d", got, err, 9)
+	}
+	wantCheckpointHash := common.BigToHash(big.NewInt(5)).Bytes()
+	if got, err := sim.ReadBTCCheckpointHashByIndex(ctx, 5); err != nil || !bytes.Equal(got, wantCheckpointHash) {
+		t.Fatalf("unexpected simulated checkpoint hash: got %x err %v want %x", got, err, wantCheckpointHash)
 	}
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -744,7 +744,10 @@ func TestSimBackendSyscoinReadersDelegate(t *testing.T) {
 	t.Parallel()
 
 	backend := testBackend{}
-	sim := &simBackend{b: backend}
+	sim := &simBackend{
+		b:    backend,
+		base: &types.Header{Number: big.NewInt(12)},
+	}
 	ctx := context.Background()
 	hash := common.HexToHash("0x5678")
 	address := common.HexToAddress("0x1234567890123456789012345678901234567890")
@@ -752,6 +755,9 @@ func TestSimBackendSyscoinReadersDelegate(t *testing.T) {
 	wantSYSHash := common.BigToHash(big.NewInt(12)).Bytes()
 	if got, err := sim.ReadSYSHash(ctx, 12); err != nil || !bytes.Equal(got, wantSYSHash) {
 		t.Fatalf("unexpected simulated SYS hash: got %x err %v want %x", got, err, wantSYSHash)
+	}
+	if got, err := sim.ReadSYSHash(ctx, 13); err != nil || len(got) != 0 {
+		t.Fatalf("simulated future SYS hash leaked canonical data: got %x err %v", got, err)
 	}
 	if got, err := sim.ReadDataHash(ctx, hash); err != nil || !bytes.Equal(got, hash.Bytes()) {
 		t.Fatalf("unexpected simulated data hash: got %x err %v want %x", got, err, hash.Bytes())

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -517,6 +517,9 @@ func (b *simBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber)
 
 // SYSCOIN
 func (b *simBackend) ReadSYSHash(ctx context.Context, number rpc.BlockNumber) ([]byte, error) {
+	if uint64(number) > b.base.Number.Uint64() {
+		return []byte{}, nil
+	}
 	return b.b.ReadSYSHash(ctx, number)
 }
 func (b *simBackend) BTCCheckpointIndex(ctx context.Context, hash common.Hash) (uint64, error) {

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -517,7 +517,7 @@ func (b *simBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber)
 
 // SYSCOIN
 func (b *simBackend) ReadSYSHash(ctx context.Context, number rpc.BlockNumber) ([]byte, error) {
-	return []byte{}, nil
+	return b.b.ReadSYSHash(ctx, number)
 }
 func (b *simBackend) BTCCheckpointIndex(ctx context.Context, hash common.Hash) (uint64, error) {
 	return b.b.BTCCheckpointIndex(ctx, hash)
@@ -529,10 +529,10 @@ func (b *simBackend) ReadBTCCheckpointHashByIndex(ctx context.Context, idx uint6
 	return b.b.ReadBTCCheckpointHashByIndex(ctx, idx)
 }
 func (b *simBackend) ReadDataHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	return []byte{}, nil
+	return b.b.ReadDataHash(ctx, hash)
 }
 func (b *simBackend) GetNEVMAddress(ctx context.Context, address common.Address) ([]byte, error) {
-	return []byte{}, nil
+	return b.b.GetNEVMAddress(ctx, address)
 }
 func (b *simBackend) ChainConfig() *params.ChainConfig {
 	return b.b.ChainConfig()


### PR DESCRIPTION
## Summary
- Delegate Syscoin `eth_simulateV1` backend readers for SYS hashes, DA hashes, and NEVM addresses to the real backend instead of returning empty bytes.
- Extend ethapi tests so both `ChainContext` and `simBackend` cover all Syscoin precompile reader paths, including BTC checkpoint readers.

## Test plan
- `go test ./internal/ethapi -run 'Test(ChainContextSyscoinReaders|SimBackendSyscoinReadersDelegate)$'`
- `go test ./internal/ethapi`


Made with [Cursor](https://cursor.com)