### PR TITLE
Migrate vault SYS balance at Liberty hard fork

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -202,22 +202,9 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 			vmContext.BlobBaseFee = eip4844.CalcBlobFee(chainConfig, header)
 		}
 	}
-	// If DAO is supported/enabled, we need to handle it here. In geth 'proper', it's
-	// done in StateProcessor.Process(block, ...), right before transactions are applied.
-	if chainConfig.DAOForkSupport &&
-		chainConfig.DAOForkBlock != nil &&
-		chainConfig.DAOForkBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
-		misc.ApplyDAOHardFork(statedb)
-	}
-	// SYSCOIN
-	if chainConfig.NexusBlock != nil &&
-		chainConfig.NexusBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
-		misc.ApplyNexusHardFork(statedb)
-	}
-	if chainConfig.VaultMigrationBlock != nil &&
-		chainConfig.VaultMigrationBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
-		misc.ApplyVaultMigrationHardFork(statedb, chainConfig.VaultManagerV2)
-	}
+	// If DAO / SYSCOIN hard forks are enabled, handle them here. In geth 'proper',
+	// this is done in StateProcessor.Process(block, ...), right before txs.
+	misc.ApplyBlockHardForks(chainConfig, new(big.Int).SetUint64(pre.Env.Number), statedb)
 	evm := vm.NewEVM(vmContext, statedb, chainConfig, vmConfig)
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -214,6 +214,10 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		chainConfig.NexusBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
 		misc.ApplyNexusHardFork(statedb)
 	}
+	if chainConfig.VaultMigrationBlock != nil &&
+		chainConfig.VaultMigrationBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
+		misc.ApplyVaultMigrationHardFork(statedb)
+	}
 	evm := vm.NewEVM(vmContext, statedb, chainConfig, vmConfig)
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -216,7 +216,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 	}
 	if chainConfig.VaultMigrationBlock != nil &&
 		chainConfig.VaultMigrationBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
-		misc.ApplyVaultMigrationHardFork(statedb)
+		misc.ApplyVaultMigrationHardFork(statedb, chainConfig.VaultManagerV2)
 	}
 	evm := vm.NewEVM(vmContext, statedb, chainConfig, vmConfig)
 	if beaconRoot := pre.Env.ParentBeaconBlockRoot; beaconRoot != nil {

--- a/consensus/misc/nexus.go
+++ b/consensus/misc/nexus.go
@@ -25,13 +25,18 @@ import (
 )
 
 // ApplyNexusHardFork transfers SYS from the pre-Nexus vault to the Nexus vault.
+// Historical Nexus behavior is preserved for zero balances: the destination
+// account is created and the source is touched via SetBalance.
 func ApplyNexusHardFork(statedb *state.StateDB) {
-	migrateVaultBalance(statedb, params.VaultManagerNexusOld, params.VaultManager)
+	migrateVaultBalance(statedb, params.VaultManagerNexusOld, params.VaultManager, false)
 }
 
 // ApplyVaultMigrationHardFork transfers SYS from the Nexus-era vault to vaultV2
 // at VaultMigrationBlock. vaultV2 should be the per-network ChainConfig address
 // (falls back to params.VaultManagerV2 when zero).
+//
+// Zero source balance is an exact no-op (unlike Nexus) so unused cutovers do
+// not create empty destination accounts.
 //
 // This is intentionally separate from LibertyBlock: Tanenbaum already activated
 // Liberty opcodes at 906001, so replaying that historical block with a new
@@ -40,21 +45,25 @@ func ApplyVaultMigrationHardFork(statedb *state.StateDB, vaultV2 common.Address)
 	if vaultV2 == (common.Address{}) {
 		vaultV2 = params.VaultManagerV2
 	}
-	migrateVaultBalance(statedb, params.VaultManager, vaultV2)
+	migrateVaultBalance(statedb, params.VaultManager, vaultV2, true)
 }
 
-func migrateVaultBalance(statedb *state.StateDB, from, to common.Address) {
+// migrateVaultBalance moves SYS from -> to. If exactNoopOnZero is true and the
+// source balance is zero, the state is left untouched. Otherwise (Nexus), a
+// missing destination is created and the source is zeroed even when empty.
+func migrateVaultBalance(statedb *state.StateDB, from, to common.Address, exactNoopOnZero bool) {
 	if from == to {
 		return
 	}
-	// Exact no-op when source has zero balance: do not CreateAccount(to).
 	oldBalance := new(uint256.Int).Set(statedb.GetBalance(from))
-	if oldBalance.IsZero() {
+	if oldBalance.IsZero() && exactNoopOnZero {
 		return
 	}
 	if !statedb.Exist(to) {
 		statedb.CreateAccount(to)
 	}
-	statedb.AddBalance(to, oldBalance, tracing.BalanceIncreaseVaultManagerContract)
+	if !oldBalance.IsZero() {
+		statedb.AddBalance(to, oldBalance, tracing.BalanceIncreaseVaultManagerContract)
+	}
 	statedb.SetBalance(from, new(uint256.Int), tracing.BalanceDecreaseVaultManagerAccount)
 }

--- a/consensus/misc/nexus.go
+++ b/consensus/misc/nexus.go
@@ -29,14 +29,18 @@ func ApplyNexusHardFork(statedb *state.StateDB) {
 	migrateVaultBalance(statedb, params.VaultManagerNexusOld, params.VaultManager)
 }
 
-// ApplyVaultMigrationHardFork transfers SYS from the Nexus-era vault to the V2
-// replacement vault at VaultMigrationBlock.
+// ApplyVaultMigrationHardFork transfers SYS from the Nexus-era vault to vaultV2
+// at VaultMigrationBlock. vaultV2 should be the per-network ChainConfig address
+// (falls back to params.VaultManagerV2 when zero).
 //
 // This is intentionally separate from LibertyBlock: Tanenbaum already activated
 // Liberty opcodes at 906001, so replaying that historical block with a new
 // balance mutation would invalidate existing state roots.
-func ApplyVaultMigrationHardFork(statedb *state.StateDB) {
-	migrateVaultBalance(statedb, params.VaultManager, params.VaultManagerV2)
+func ApplyVaultMigrationHardFork(statedb *state.StateDB, vaultV2 common.Address) {
+	if vaultV2 == (common.Address{}) {
+		vaultV2 = params.VaultManagerV2
+	}
+	migrateVaultBalance(statedb, params.VaultManager, vaultV2)
 }
 
 func migrateVaultBalance(statedb *state.StateDB, from, to common.Address) {

--- a/consensus/misc/nexus.go
+++ b/consensus/misc/nexus.go
@@ -29,12 +29,13 @@ func ApplyNexusHardFork(statedb *state.StateDB) {
 	migrateVaultBalance(statedb, params.VaultManagerNexusOld, params.VaultManager)
 }
 
-// ApplyLibertyHardFork transfers SYS from the Nexus-era vault to the Liberty
-// replacement vault at LibertyBlock (shared mainnet/tanenbaum rule).
+// ApplyVaultMigrationHardFork transfers SYS from the Nexus-era vault to the V2
+// replacement vault at VaultMigrationBlock.
 //
-// Tanenbaum LibertyBlock is already 906001; activating this requires every
-// tanenbaum node to replay from that height (no TokenFreeze logs after it).
-func ApplyLibertyHardFork(statedb *state.StateDB) {
+// This is intentionally separate from LibertyBlock: Tanenbaum already activated
+// Liberty opcodes at 906001, so replaying that historical block with a new
+// balance mutation would invalidate existing state roots.
+func ApplyVaultMigrationHardFork(statedb *state.StateDB) {
 	migrateVaultBalance(statedb, params.VaultManager, params.VaultManagerV2)
 }
 
@@ -42,13 +43,13 @@ func migrateVaultBalance(statedb *state.StateDB, from, to common.Address) {
 	if from == to {
 		return
 	}
-	if !statedb.Exist(to) {
-		statedb.CreateAccount(to)
-	}
-	// Copy before mutating `from` so AddBalance cannot observe a zeroed source.
+	// Exact no-op when source has zero balance: do not CreateAccount(to).
 	oldBalance := new(uint256.Int).Set(statedb.GetBalance(from))
 	if oldBalance.IsZero() {
 		return
+	}
+	if !statedb.Exist(to) {
+		statedb.CreateAccount(to)
 	}
 	statedb.AddBalance(to, oldBalance, tracing.BalanceIncreaseVaultManagerContract)
 	statedb.SetBalance(from, new(uint256.Int), tracing.BalanceDecreaseVaultManagerAccount)

--- a/consensus/misc/nexus.go
+++ b/consensus/misc/nexus.go
@@ -17,12 +17,31 @@
 package misc
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
+
+// ApplyBlockHardForks applies one-shot state mutations that occur at specific
+// block numbers before transaction execution (DAO, Nexus, VaultMigration).
+// Callers that re-execute a block without going through StateProcessor.Process
+// (debug/trace paths) must invoke this so pre-tx state matches consensus.
+func ApplyBlockHardForks(config *params.ChainConfig, number *big.Int, statedb *state.StateDB) {
+	if config.DAOForkSupport && config.DAOForkBlock != nil && config.DAOForkBlock.Cmp(number) == 0 {
+		ApplyDAOHardFork(statedb)
+	}
+	// SYSCOIN
+	if config.NexusBlock != nil && config.NexusBlock.Cmp(number) == 0 {
+		ApplyNexusHardFork(statedb)
+	}
+	if config.VaultMigrationBlock != nil && config.VaultMigrationBlock.Cmp(number) == 0 {
+		ApplyVaultMigrationHardFork(statedb, config.VaultManagerV2)
+	}
+}
 
 // ApplyNexusHardFork transfers SYS from the pre-Nexus vault to the Nexus vault.
 // Historical Nexus behavior is preserved for zero balances: the destination

--- a/consensus/misc/nexus.go
+++ b/consensus/misc/nexus.go
@@ -17,24 +17,39 @@
 package misc
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/params"
-    "github.com/ethereum/go-ethereum/core/tracing"
-    "github.com/holiman/uint256"
+	"github.com/holiman/uint256"
 )
 
-
-// ApplyNexusHardFork modifies the state database according to the Nexus hard-fork
-// rules, transferring SYS balance from previous VaultManager to new one
+// ApplyNexusHardFork transfers SYS from the pre-Nexus vault to the Nexus vault.
 func ApplyNexusHardFork(statedb *state.StateDB) {
-    // Create the new contract account if it doesn't already exist
-    if !statedb.Exist(params.VaultManager) {
-        statedb.CreateAccount(params.VaultManager)
-    }
+	migrateVaultBalance(statedb, params.VaultManagerNexusOld, params.VaultManager)
+}
 
-    // Transfer the balance from the old contract to the new contract
-    oldBalance := statedb.GetBalance(params.VaultManagerOld)
-    statedb.AddBalance(params.VaultManager, oldBalance, tracing.BalanceIncreaseVaultManagerContract)
-    statedb.SetBalance(params.VaultManagerOld, new(uint256.Int), tracing.BalanceDecreaseVaultManagerAccount)// Reset the old contract's balance
+// ApplyLibertyHardFork transfers SYS from the Nexus-era vault to the Liberty
+// replacement vault at LibertyBlock (shared mainnet/tanenbaum rule).
+//
+// Tanenbaum LibertyBlock is already 906001; activating this requires every
+// tanenbaum node to replay from that height (no TokenFreeze logs after it).
+func ApplyLibertyHardFork(statedb *state.StateDB) {
+	migrateVaultBalance(statedb, params.VaultManager, params.VaultManagerV2)
+}
 
+func migrateVaultBalance(statedb *state.StateDB, from, to common.Address) {
+	if from == to {
+		return
+	}
+	if !statedb.Exist(to) {
+		statedb.CreateAccount(to)
+	}
+	// Copy before mutating `from` so AddBalance cannot observe a zeroed source.
+	oldBalance := new(uint256.Int).Set(statedb.GetBalance(from))
+	if oldBalance.IsZero() {
+		return
+	}
+	statedb.AddBalance(to, oldBalance, tracing.BalanceIncreaseVaultManagerContract)
+	statedb.SetBalance(from, new(uint256.Int), tracing.BalanceDecreaseVaultManagerAccount)
 }

--- a/consensus/misc/nexus_test.go
+++ b/consensus/misc/nexus_test.go
@@ -34,19 +34,32 @@ func TestApplyVaultMigrationHardForkAddsWithoutOverwrite(t *testing.T) {
 	}
 }
 
-func TestMigrateVaultBalanceZeroIsExactNoop(t *testing.T) {
+func TestMigrateVaultBalanceZeroIsExactNoopForV2(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	from := params.VaultManager
 	to := params.VaultManagerV2
 	statedb.CreateAccount(from)
-	// Zero balance on from; to must remain non-existent.
 	rootBefore := statedb.IntermediateRoot(false)
-	migrateVaultBalance(statedb, from, to)
+	migrateVaultBalance(statedb, from, to, true)
 	if statedb.Exist(to) {
-		t.Fatal("zero-balance migrate created destination account")
+		t.Fatal("zero-balance V2 migrate created destination account")
 	}
 	if rootAfter := statedb.IntermediateRoot(false); rootAfter != rootBefore {
-		t.Fatalf("zero-balance migrate changed state root: before=%s after=%s", rootBefore, rootAfter)
+		t.Fatalf("zero-balance V2 migrate changed state root: before=%s after=%s", rootBefore, rootAfter)
+	}
+}
+
+func TestNexusZeroBalanceCreatesDestination(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	from := params.VaultManagerNexusOld
+	to := params.VaultManager
+	statedb.CreateAccount(from)
+	ApplyNexusHardFork(statedb)
+	if !statedb.Exist(to) {
+		t.Fatal("Nexus zero-balance migrate did not create destination")
+	}
+	if got := statedb.GetBalance(from); !got.IsZero() {
+		t.Fatalf("source balance=%s want 0", got)
 	}
 }
 
@@ -55,7 +68,7 @@ func TestMigrateVaultBalanceSkipsIdenticalAddresses(t *testing.T) {
 	addr := common.HexToAddress("0xabc0000000000000000000000000000000000001")
 	statedb.CreateAccount(addr)
 	statedb.AddBalance(addr, uint256.NewInt(7), tracing.BalanceChangeUnspecified)
-	migrateVaultBalance(statedb, addr, addr)
+	migrateVaultBalance(statedb, addr, addr, true)
 	if got := statedb.GetBalance(addr); got.Cmp(uint256.NewInt(7)) != 0 {
 		t.Fatalf("balance changed on self-migrate: %s", got)
 	}

--- a/consensus/misc/nexus_test.go
+++ b/consensus/misc/nexus_test.go
@@ -24,7 +24,7 @@ func TestApplyVaultMigrationHardForkAddsWithoutOverwrite(t *testing.T) {
 	statedb.AddBalance(old, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
 	statedb.AddBalance(neu, uint256.NewInt(50), tracing.BalanceChangeUnspecified)
 
-	ApplyVaultMigrationHardFork(statedb)
+	ApplyVaultMigrationHardFork(statedb, neu)
 
 	if got := statedb.GetBalance(neu); got.Cmp(uint256.NewInt(1050)) != 0 {
 		t.Fatalf("new vault balance=%s want 1050", got)

--- a/consensus/misc/nexus_test.go
+++ b/consensus/misc/nexus_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/holiman/uint256"
 )
 
-func TestApplyLibertyHardForkAddsWithoutOverwrite(t *testing.T) {
+func TestApplyVaultMigrationHardForkAddsWithoutOverwrite(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
 	old := params.VaultManager
 	neu := params.VaultManagerV2
@@ -24,13 +24,29 @@ func TestApplyLibertyHardForkAddsWithoutOverwrite(t *testing.T) {
 	statedb.AddBalance(old, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
 	statedb.AddBalance(neu, uint256.NewInt(50), tracing.BalanceChangeUnspecified)
 
-	ApplyLibertyHardFork(statedb)
+	ApplyVaultMigrationHardFork(statedb)
 
 	if got := statedb.GetBalance(neu); got.Cmp(uint256.NewInt(1050)) != 0 {
 		t.Fatalf("new vault balance=%s want 1050", got)
 	}
 	if got := statedb.GetBalance(old); !got.IsZero() {
 		t.Fatalf("old vault balance=%s want 0", got)
+	}
+}
+
+func TestMigrateVaultBalanceZeroIsExactNoop(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	from := params.VaultManager
+	to := params.VaultManagerV2
+	statedb.CreateAccount(from)
+	// Zero balance on from; to must remain non-existent.
+	rootBefore := statedb.IntermediateRoot(false)
+	migrateVaultBalance(statedb, from, to)
+	if statedb.Exist(to) {
+		t.Fatal("zero-balance migrate created destination account")
+	}
+	if rootAfter := statedb.IntermediateRoot(false); rootAfter != rootBefore {
+		t.Fatalf("zero-balance migrate changed state root: before=%s after=%s", rootBefore, rootAfter)
 	}
 }
 

--- a/consensus/misc/nexus_test.go
+++ b/consensus/misc/nexus_test.go
@@ -4,6 +4,7 @@
 package misc
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +14,30 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
+
+func TestApplyBlockHardForksVaultMigration(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	old := params.VaultManager
+	neu := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	statedb.CreateAccount(old)
+	statedb.AddBalance(old, uint256.NewInt(500), tracing.BalanceChangeUnspecified)
+
+	cfg := &params.ChainConfig{
+		VaultMigrationBlock: big.NewInt(42),
+		VaultManagerV2:      neu,
+	}
+	ApplyBlockHardForks(cfg, big.NewInt(41), statedb)
+	if got := statedb.GetBalance(old); got.Cmp(uint256.NewInt(500)) != 0 {
+		t.Fatalf("pre-fork mutate: old=%s want 500", got)
+	}
+	ApplyBlockHardForks(cfg, big.NewInt(42), statedb)
+	if got := statedb.GetBalance(neu); got.Cmp(uint256.NewInt(500)) != 0 {
+		t.Fatalf("migration block: new=%s want 500", got)
+	}
+	if got := statedb.GetBalance(old); !got.IsZero() {
+		t.Fatalf("migration block: old=%s want 0", got)
+	}
+}
 
 func TestApplyVaultMigrationHardForkAddsWithoutOverwrite(t *testing.T) {
 	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())

--- a/consensus/misc/nexus_test.go
+++ b/consensus/misc/nexus_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package misc
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+func TestApplyLibertyHardForkAddsWithoutOverwrite(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	old := params.VaultManager
+	neu := params.VaultManagerV2
+
+	statedb.CreateAccount(old)
+	statedb.CreateAccount(neu)
+	statedb.AddBalance(old, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
+	statedb.AddBalance(neu, uint256.NewInt(50), tracing.BalanceChangeUnspecified)
+
+	ApplyLibertyHardFork(statedb)
+
+	if got := statedb.GetBalance(neu); got.Cmp(uint256.NewInt(1050)) != 0 {
+		t.Fatalf("new vault balance=%s want 1050", got)
+	}
+	if got := statedb.GetBalance(old); !got.IsZero() {
+		t.Fatalf("old vault balance=%s want 0", got)
+	}
+}
+
+func TestMigrateVaultBalanceSkipsIdenticalAddresses(t *testing.T) {
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	addr := common.HexToAddress("0xabc0000000000000000000000000000000000001")
+	statedb.CreateAccount(addr)
+	statedb.AddBalance(addr, uint256.NewInt(7), tracing.BalanceChangeUnspecified)
+	migrateVaultBalance(statedb, addr, addr)
+	if got := statedb.GetBalance(addr); got.Cmp(uint256.NewInt(7)) != 0 {
+		t.Fatalf("balance changed on self-migrate: %s", got)
+	}
+}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -386,16 +386,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 				}
 			}
 		}
-		if config.DAOForkSupport && config.DAOForkBlock != nil && config.DAOForkBlock.Cmp(b.header.Number) == 0 {
-			misc.ApplyDAOHardFork(statedb)
-		}
-		// SYSCOIN
-		if config.NexusBlock != nil && config.NexusBlock.Cmp(b.header.Number) == 0 {
-			misc.ApplyNexusHardFork(statedb)
-		}
-		if config.VaultMigrationBlock != nil && config.VaultMigrationBlock.Cmp(b.header.Number) == 0 {
-			misc.ApplyVaultMigrationHardFork(statedb, config.VaultManagerV2)
-		}
+		misc.ApplyBlockHardForks(config, b.header.Number, statedb)
 		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
 			// EIP-2935
 			blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -394,7 +394,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyNexusHardFork(statedb)
 		}
 		if config.VaultMigrationBlock != nil && config.VaultMigrationBlock.Cmp(b.header.Number) == 0 {
-			misc.ApplyVaultMigrationHardFork(statedb)
+			misc.ApplyVaultMigrationHardFork(statedb, config.VaultManagerV2)
 		}
 		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
 			// EIP-2935

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -393,6 +393,9 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		if config.NexusBlock != nil && config.NexusBlock.Cmp(b.header.Number) == 0 {
 			misc.ApplyNexusHardFork(statedb)
 		}
+		if config.LibertyBlock != nil && config.LibertyBlock.Cmp(b.header.Number) == 0 {
+			misc.ApplyLibertyHardFork(statedb)
+		}
 		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
 			// EIP-2935
 			blockContext := NewEVMBlockContext(b.header, cm, &b.header.Coinbase)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -393,8 +393,8 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		if config.NexusBlock != nil && config.NexusBlock.Cmp(b.header.Number) == 0 {
 			misc.ApplyNexusHardFork(statedb)
 		}
-		if config.LibertyBlock != nil && config.LibertyBlock.Cmp(b.header.Number) == 0 {
-			misc.ApplyLibertyHardFork(statedb)
+		if config.VaultMigrationBlock != nil && config.VaultMigrationBlock.Cmp(b.header.Number) == 0 {
+			misc.ApplyVaultMigrationHardFork(statedb)
 		}
 		if config.IsPrague(b.header.Number, b.header.Time) || config.IsVerkle(b.header.Number, b.header.Time) {
 			// EIP-2935

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -66,16 +66,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	)
 
 	// Mutate the block and state according to any hard-fork specs
-	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
-		misc.ApplyDAOHardFork(statedb)
-	}
-	// SYSCOIN
-	if p.config.NexusBlock != nil && p.config.NexusBlock.Cmp(block.Number()) == 0 {
-		misc.ApplyNexusHardFork(statedb)
-	}
-	if p.config.VaultMigrationBlock != nil && p.config.VaultMigrationBlock.Cmp(block.Number()) == 0 {
-		misc.ApplyVaultMigrationHardFork(statedb, p.config.VaultManagerV2)
-	}
+	misc.ApplyBlockHardForks(p.config, block.Number(), statedb)
 	var (
 		context vm.BlockContext
 		signer  = types.MakeSigner(p.config, header.Number, header.Time)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -74,7 +74,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		misc.ApplyNexusHardFork(statedb)
 	}
 	if p.config.VaultMigrationBlock != nil && p.config.VaultMigrationBlock.Cmp(block.Number()) == 0 {
-		misc.ApplyVaultMigrationHardFork(statedb)
+		misc.ApplyVaultMigrationHardFork(statedb, p.config.VaultManagerV2)
 	}
 	var (
 		context vm.BlockContext

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -73,6 +73,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.NexusBlock != nil && p.config.NexusBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyNexusHardFork(statedb)
 	}
+	if p.config.LibertyBlock != nil && p.config.LibertyBlock.Cmp(block.Number()) == 0 {
+		misc.ApplyLibertyHardFork(statedb)
+	}
 	var (
 		context vm.BlockContext
 		signer  = types.MakeSigner(p.config, header.Number, header.Time)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -73,8 +73,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.NexusBlock != nil && p.config.NexusBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyNexusHardFork(statedb)
 	}
-	if p.config.LibertyBlock != nil && p.config.LibertyBlock.Cmp(block.Number()) == 0 {
-		misc.ApplyLibertyHardFork(statedb)
+	if p.config.VaultMigrationBlock != nil && p.config.VaultMigrationBlock.Cmp(block.Number()) == 0 {
+		misc.ApplyVaultMigrationHardFork(statedb)
 	}
 	var (
 		context vm.BlockContext

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -234,6 +235,8 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	if err != nil {
 		return nil, vm.BlockContext{}, nil, nil, err
 	}
+	// Match StateProcessor.Process hard-fork mutations before replaying txs.
+	misc.ApplyBlockHardForks(eth.blockchain.Config(), block.Number(), statedb)
 	// Insert parent beacon block root in the state as per EIP-4788.
 	context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
 	evm := vm.NewEVM(context, statedb, eth.blockchain.Config(), vm.Config{})

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1142,6 +1142,23 @@ func overrideConfig(original *params.ChainConfig, override *params.ChainConfig) 
 		copy.VerkleTime = timestamp
 		canon = false
 	}
+	// SYSCOIN — allow debug_standardTraceBlockToFile to simulate vault cutover.
+	if block := override.NexusBlock; block != nil {
+		copy.NexusBlock = block
+		canon = false
+	}
+	if block := override.LibertyBlock; block != nil {
+		copy.LibertyBlock = block
+		canon = false
+	}
+	if block := override.VaultMigrationBlock; block != nil {
+		copy.VaultMigrationBlock = block
+		canon = false
+	}
+	if override.VaultManagerV2 != (common.Address{}) {
+		copy.VaultManagerV2 = override.VaultManagerV2
+		canon = false
+	}
 
 	return copy, canon
 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -407,6 +408,8 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				failed = err
 				break
 			}
+			// Match StateProcessor.Process hard-fork mutations before replaying txs.
+			misc.ApplyBlockHardForks(api.backend.ChainConfig(), next.Number(), statedb)
 			// Insert block's parent beacon block root in the state
 			// as per EIP-4788.
 			context := core.NewEVMBlockContext(next.Header(), api.chainContext(ctx), nil)
@@ -566,6 +569,8 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
 	)
+	// Match StateProcessor.Process hard-fork mutations before replaying txs.
+	misc.ApplyBlockHardForks(chainConfig, block.Number(), statedb)
 	evm := vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)
@@ -629,6 +634,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	}
 	defer release()
 
+	// Match StateProcessor.Process hard-fork mutations before replaying txs.
+	misc.ApplyBlockHardForks(api.backend.ChainConfig(), block.Number(), statedb)
 	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	evm := vm.NewEVM(blockCtx, statedb, api.backend.ChainConfig(), vm.Config{})
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
@@ -807,6 +814,9 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Note: This copies the config, to not screw up the main config
 		chainConfig, canon = overrideConfig(chainConfig, config.Overrides)
 	}
+	// Match StateProcessor.Process hard-fork mutations before replaying txs.
+	// Use (possibly overridden) chainConfig so vaultMigrationBlock overrides apply.
+	misc.ApplyBlockHardForks(chainConfig, block.Number(), statedb)
 	evm := vm.NewEVM(vmctx, statedb, chainConfig, vm.Config{})
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*beaconRoot, evm)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -1234,3 +1234,28 @@ func TestTraceBlockWithBasefee(t *testing.T) {
 		}
 	}
 }
+
+func TestOverrideConfigVaultMigration(t *testing.T) {
+	original := &params.ChainConfig{
+		NexusBlock:          big.NewInt(10),
+		VaultMigrationBlock: nil,
+	}
+	v2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	over := &params.ChainConfig{
+		VaultMigrationBlock: big.NewInt(42),
+		VaultManagerV2:      v2,
+	}
+	cfg, canon := overrideConfig(original, over)
+	if canon {
+		t.Fatal("expected non-canonical after vault override")
+	}
+	if cfg.VaultMigrationBlock == nil || cfg.VaultMigrationBlock.Cmp(big.NewInt(42)) != 0 {
+		t.Fatalf("VaultMigrationBlock=%v want 42", cfg.VaultMigrationBlock)
+	}
+	if cfg.VaultManagerV2 != v2 {
+		t.Fatalf("VaultManagerV2=%s want %s", cfg.VaultManagerV2, v2)
+	}
+	if original.VaultMigrationBlock != nil {
+		t.Fatal("override mutated original config")
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -243,15 +243,8 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		log.Error("Failed to create sealing context", "err", err)
 		return nil, err
 	}
-	// SYSCOIN
-	if miner.chainConfig.NexusBlock != nil &&
-		miner.chainConfig.NexusBlock.Cmp(header.Number) == 0 {
-		misc.ApplyNexusHardFork(env.state)
-	}
-	if miner.chainConfig.VaultMigrationBlock != nil &&
-		miner.chainConfig.VaultMigrationBlock.Cmp(header.Number) == 0 {
-		misc.ApplyVaultMigrationHardFork(env.state, miner.chainConfig.VaultManagerV2)
-	}
+	// SYSCOIN — match StateProcessor.Process hard-fork mutations
+	misc.ApplyBlockHardForks(miner.chainConfig, header.Number, env.state)
 	if header.ParentBeaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -248,9 +248,9 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		miner.chainConfig.NexusBlock.Cmp(header.Number) == 0 {
 		misc.ApplyNexusHardFork(env.state)
 	}
-	if miner.chainConfig.LibertyBlock != nil &&
-		miner.chainConfig.LibertyBlock.Cmp(header.Number) == 0 {
-		misc.ApplyLibertyHardFork(env.state)
+	if miner.chainConfig.VaultMigrationBlock != nil &&
+		miner.chainConfig.VaultMigrationBlock.Cmp(header.Number) == 0 {
+		misc.ApplyVaultMigrationHardFork(env.state)
 	}
 	if header.ParentBeaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -250,7 +250,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	}
 	if miner.chainConfig.VaultMigrationBlock != nil &&
 		miner.chainConfig.VaultMigrationBlock.Cmp(header.Number) == 0 {
-		misc.ApplyVaultMigrationHardFork(env.state)
+		misc.ApplyVaultMigrationHardFork(env.state, miner.chainConfig.VaultManagerV2)
 	}
 	if header.ParentBeaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -248,6 +248,10 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		miner.chainConfig.NexusBlock.Cmp(header.Number) == 0 {
 		misc.ApplyNexusHardFork(env.state)
 	}
+	if miner.chainConfig.LibertyBlock != nil &&
+		miner.chainConfig.LibertyBlock.Cmp(header.Number) == 0 {
+		misc.ApplyLibertyHardFork(env.state)
+	}
 	if header.ParentBeaconRoot != nil {
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, env.evm)
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -92,6 +92,7 @@ var (
 		NexusBlock:              big.NewInt(692846),
 		LibertyBlock:            nil,
 		VaultMigrationBlock:     nil, // set to future F when V2 vault proxy is deployed
+		VaultManagerV2:          VaultManagerV2, // stub until proxy deployed; per-network
 		LondonBlock:             big.NewInt(1),
 		TerminalTotalDifficulty: big.NewInt(1),
 		//ShanghaiTime:                  newUint64(1679618404),
@@ -124,6 +125,8 @@ var (
 		// migrate vault balances. Set to future NEVM height F when the V2 proxy
 		// is deployed (paired with Core nBridgeV2StartBlock).
 		VaultMigrationBlock: nil,
+		// Per-network V2 vault; stub until proxy is deployed (may differ from mainnet).
+		VaultManagerV2: VaultManagerV2,
 		LondonBlock:         big.NewInt(1),
 		//CancunTime:          newUint64(1675118284),
 		TerminalTotalDifficulty: big.NewInt(1),
@@ -473,6 +476,9 @@ type ChainConfig struct {
 	NexusBlock          *big.Int `json:"nexusBlock,omitempty"`          // Nexus switch block (nil = no fork, 0 = already on syscoin)
 	LibertyBlock        *big.Int `json:"libertyBlock,omitempty"`        // Liberty opcode switch block (nil = no fork, 0 = already on syscoin)
 	VaultMigrationBlock *big.Int `json:"vaultMigrationBlock,omitempty"` // Bridge V2 vault balance migration block (nil = no fork)
+	// VaultManagerV2 is the destination for VaultMigrationBlock balance move.
+	// Per-network so Tanenbaum and mainnet may use different UUPS proxy addresses.
+	VaultManagerV2 common.Address `json:"vaultManagerV2,omitempty"`
 	// Fork scheduling was switched from blocks to timestamps here
 
 	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty"` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
@@ -871,6 +877,10 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		if c.VaultMigrationBlock.Cmp(c.NexusBlock) < 0 {
 			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) is before nexusBlock (%v)",
 				c.VaultMigrationBlock, c.NexusBlock)
+		}
+		if c.VaultManagerV2 == (common.Address{}) {
+			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) set without vaultManagerV2 address",
+				c.VaultMigrationBlock)
 		}
 	}
 

--- a/params/config.go
+++ b/params/config.go
@@ -859,6 +859,12 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		}
 	}
 
+	// SYSCOIN: vault migration must not precede Nexus (balance only exists after Nexus).
+	if c.VaultMigrationBlock != nil && c.NexusBlock != nil && c.VaultMigrationBlock.Cmp(c.NexusBlock) < 0 {
+		return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) is before nexusBlock (%v)",
+			c.VaultMigrationBlock, c.NexusBlock)
+	}
+
 	// Check that all forks with blobs explicitly define the blob schedule configuration.
 	bsc := c.BlobScheduleConfig
 	if bsc == nil {

--- a/params/config.go
+++ b/params/config.go
@@ -91,6 +91,7 @@ var (
 		ShanghaiBlock:           big.NewInt(268500),
 		NexusBlock:              big.NewInt(692846),
 		LibertyBlock:            nil,
+		VaultMigrationBlock:     nil, // set to future F when V2 vault proxy is deployed
 		LondonBlock:             big.NewInt(1),
 		TerminalTotalDifficulty: big.NewInt(1),
 		//ShanghaiTime:                  newUint64(1679618404),
@@ -117,9 +118,10 @@ var (
 		RolluxBlock:         big.NewInt(182500),
 		ShanghaiBlock:       big.NewInt(223000),
 		//ShanghaiTime:        newUint64(1675118284),
-		NexusBlock:   big.NewInt(665001),
-		LibertyBlock: big.NewInt(906001),
-		LondonBlock:  big.NewInt(1),
+		NexusBlock:          big.NewInt(665001),
+		LibertyBlock:        big.NewInt(906001), // opcode fork only; already historical
+		VaultMigrationBlock: nil,                // future F2; do not reuse LibertyBlock
+		LondonBlock:         big.NewInt(1),
 		//CancunTime:          newUint64(1675118284),
 		TerminalTotalDifficulty: big.NewInt(1),
 		Ethash:                  nil,
@@ -465,8 +467,9 @@ type ChainConfig struct {
 	SyscoinBlock  *big.Int `json:"syscoinBlock,omitempty"`  // Syscoin switch block (nil = no fork, 0 = already on syscoin)
 	RolluxBlock   *big.Int `json:"rolluxBlock,omitempty"`   // Rollux switch block (nil = no fork, 0 = already on syscoin)
 	ShanghaiBlock *big.Int `json:"shanghaiBlock,omitempty"` // Rollux switch block (nil = no fork, 0 = already on syscoin)
-	NexusBlock    *big.Int `json:"nexusBlock,omitempty"`    // Nexus switch block (nil = no fork, 0 = already on syscoin)
-	LibertyBlock  *big.Int `json:"libertyBlock,omitempty"`  // Liberty opcode switch block (nil = no fork, 0 = already on syscoin)
+	NexusBlock          *big.Int `json:"nexusBlock,omitempty"`          // Nexus switch block (nil = no fork, 0 = already on syscoin)
+	LibertyBlock        *big.Int `json:"libertyBlock,omitempty"`        // Liberty opcode switch block (nil = no fork, 0 = already on syscoin)
+	VaultMigrationBlock *big.Int `json:"vaultMigrationBlock,omitempty"` // Bridge V2 vault balance migration block (nil = no fork)
 	// Fork scheduling was switched from blocks to timestamps here
 
 	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty"` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
@@ -709,6 +712,11 @@ func (c *ChainConfig) IsNexus(num *big.Int) bool {
 // SYSCOIN
 func (c *ChainConfig) IsLiberty(num *big.Int) bool {
 	return isBlockForked(c.LibertyBlock, num)
+}
+
+// IsVaultMigration returns whether num is at or past the bridge V2 vault migration block.
+func (c *ChainConfig) IsVaultMigration(num *big.Int) bool {
+	return isBlockForked(c.VaultMigrationBlock, num)
 }
 
 // IsShanghai returns whether time is either equal to the Shanghai fork time or greater.
@@ -960,6 +968,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkBlockIncompatible(c.LibertyBlock, newcfg.LibertyBlock, headNumber) {
 		return newBlockCompatError("Liberty fork block", c.LibertyBlock, newcfg.LibertyBlock)
+	}
+	if isForkBlockIncompatible(c.VaultMigrationBlock, newcfg.VaultMigrationBlock, headNumber) {
+		return newBlockCompatError("Vault migration fork block", c.VaultMigrationBlock, newcfg.VaultMigrationBlock)
 	}
 	if isForkTimestampIncompatible(c.ShanghaiTime, newcfg.ShanghaiTime, headTimestamp) {
 		return newTimestampCompatError("Shanghai fork timestamp", c.ShanghaiTime, newcfg.ShanghaiTime)

--- a/params/config.go
+++ b/params/config.go
@@ -862,10 +862,16 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		}
 	}
 
-	// SYSCOIN: vault migration must not precede Nexus (balance only exists after Nexus).
-	if c.VaultMigrationBlock != nil && c.NexusBlock != nil && c.VaultMigrationBlock.Cmp(c.NexusBlock) < 0 {
-		return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) is before nexusBlock (%v)",
-			c.VaultMigrationBlock, c.NexusBlock)
+	// SYSCOIN: vault migration requires Nexus first (balance only exists after Nexus).
+	if c.VaultMigrationBlock != nil {
+		if c.NexusBlock == nil {
+			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) set without nexusBlock",
+				c.VaultMigrationBlock)
+		}
+		if c.VaultMigrationBlock.Cmp(c.NexusBlock) < 0 {
+			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) is before nexusBlock (%v)",
+				c.VaultMigrationBlock, c.NexusBlock)
+		}
 	}
 
 	// Check that all forks with blobs explicitly define the blob schedule configuration.

--- a/params/config.go
+++ b/params/config.go
@@ -869,6 +869,11 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 
 	// SYSCOIN: vault migration requires Nexus first (balance only exists after Nexus).
 	if c.VaultMigrationBlock != nil {
+		// Block 0 is committed via Genesis, not StateProcessor — migration would never run.
+		if c.VaultMigrationBlock.Sign() == 0 {
+			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock must be > 0 (got %v)",
+				c.VaultMigrationBlock)
+		}
 		if c.NexusBlock == nil {
 			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) set without nexusBlock",
 				c.VaultMigrationBlock)

--- a/params/config.go
+++ b/params/config.go
@@ -119,8 +119,11 @@ var (
 		ShanghaiBlock:       big.NewInt(223000),
 		//ShanghaiTime:        newUint64(1675118284),
 		NexusBlock:          big.NewInt(665001),
-		LibertyBlock:        big.NewInt(906001), // opcode fork only; already historical
-		VaultMigrationBlock: nil,                // future F2; do not reuse LibertyBlock
+		LibertyBlock: big.NewInt(906001), // opcode fork only; already historical
+		// Intentionally nil until Bridge V2 cutover: a past LibertyBlock must not
+		// migrate vault balances. Set to future NEVM height F when the V2 proxy
+		// is deployed (paired with Core nBridgeV2StartBlock).
+		VaultMigrationBlock: nil,
 		LondonBlock:         big.NewInt(1),
 		//CancunTime:          newUint64(1675118284),
 		TerminalTotalDifficulty: big.NewInt(1),

--- a/params/config.go
+++ b/params/config.go
@@ -891,6 +891,11 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) still uses stub vaultManagerV2 (%v)",
 				c.VaultMigrationBlock, c.VaultManagerV2)
 		}
+		// from == to is a no-op in migrateVaultBalance; reject accidental self-migration.
+		if c.VaultManagerV2 == VaultManager {
+			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) vaultManagerV2 equals current VaultManager (%v)",
+				c.VaultMigrationBlock, c.VaultManagerV2)
+		}
 	}
 
 	// Check that all forks with blobs explicitly define the blob schedule configuration.

--- a/params/config.go
+++ b/params/config.go
@@ -91,8 +91,8 @@ var (
 		ShanghaiBlock:           big.NewInt(268500),
 		NexusBlock:              big.NewInt(692846),
 		LibertyBlock:            nil,
-		VaultMigrationBlock:     nil, // set to future F when V2 vault proxy is deployed
-		VaultManagerV2:          VaultManagerV2, // stub until proxy deployed; per-network
+		VaultMigrationBlock: nil, // set to future F when V2 vault proxy is deployed
+		// VaultManagerV2 left zero until the real proxy address is set with F.
 		LondonBlock:             big.NewInt(1),
 		TerminalTotalDifficulty: big.NewInt(1),
 		//ShanghaiTime:                  newUint64(1679618404),
@@ -125,8 +125,7 @@ var (
 		// migrate vault balances. Set to future NEVM height F when the V2 proxy
 		// is deployed (paired with Core nBridgeV2StartBlock).
 		VaultMigrationBlock: nil,
-		// Per-network V2 vault; stub until proxy is deployed (may differ from mainnet).
-		VaultManagerV2: VaultManagerV2,
+		// VaultManagerV2 left zero until the real proxy address is set with F.
 		LondonBlock:         big.NewInt(1),
 		//CancunTime:          newUint64(1675118284),
 		TerminalTotalDifficulty: big.NewInt(1),
@@ -882,6 +881,11 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) set without vaultManagerV2 address",
 				c.VaultMigrationBlock)
 		}
+		// Reject the package stub so cutover cannot be a one-line F-only update.
+		if c.VaultManagerV2 == VaultManagerV2 {
+			return fmt.Errorf("unsupported fork ordering: vaultMigrationBlock (%v) still uses stub vaultManagerV2 (%v)",
+				c.VaultMigrationBlock, c.VaultManagerV2)
+		}
 	}
 
 	// Check that all forks with blobs explicitly define the blob schedule configuration.
@@ -996,6 +1000,11 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkBlockIncompatible(c.VaultMigrationBlock, newcfg.VaultMigrationBlock, headNumber) {
 		return newBlockCompatError("Vault migration fork block", c.VaultMigrationBlock, newcfg.VaultMigrationBlock)
+	}
+	// Destination address is consensus-critical once the migration fork is in the past.
+	if (isBlockForked(c.VaultMigrationBlock, headNumber) || isBlockForked(newcfg.VaultMigrationBlock, headNumber)) &&
+		c.VaultManagerV2 != newcfg.VaultManagerV2 {
+		return newBlockCompatError("Vault migration V2 address", c.VaultMigrationBlock, newcfg.VaultMigrationBlock)
 	}
 	if isForkTimestampIncompatible(c.ShanghaiTime, newcfg.ShanghaiTime, headTimestamp) {
 		return newTimestampCompatError("Shanghai fork timestamp", c.ShanghaiTime, newcfg.ShanghaiTime)

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -20,11 +20,35 @@ import (
 	"math"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCheckConfigForkOrderVaultMigration(t *testing.T) {
+	validV2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	cfg := func(v2 common.Address) *ChainConfig {
+		return &ChainConfig{
+			NexusBlock:          big.NewInt(1),
+			VaultMigrationBlock: big.NewInt(2),
+			VaultManagerV2:      v2,
+		}
+	}
+	if err := cfg(validV2).CheckConfigForkOrder(); err != nil {
+		t.Fatalf("valid vaultManagerV2 rejected: %v", err)
+	}
+	if err := cfg(VaultManager).CheckConfigForkOrder(); err == nil {
+		t.Fatal("expected reject when vaultManagerV2 equals VaultManager")
+	} else if !strings.Contains(err.Error(), "equals current VaultManager") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := cfg(VaultManagerV2).CheckConfigForkOrder(); err == nil {
+		t.Fatal("expected reject stub vaultManagerV2")
+	}
+}
 
 func TestCheckCompatible(t *testing.T) {
 	type test struct {

--- a/params/nexus.go
+++ b/params/nexus.go
@@ -9,16 +9,17 @@ import (
 // Nexus (activated): VaultManagerNexusOld → VaultManager
 // Bridge V2 (at VaultMigrationBlock): VaultManager → VaultManagerV2
 //
-// Package-level VaultManagerV2 is the default stub used by tests and as the
-// initial ChainConfig.VaultManagerV2 for each network. Replace the per-network
-// ChainConfig field with the deployed UUPS vault proxy before setting that
-// network's VaultMigrationBlock. Do not couple migration to LibertyBlock on
-// networks where Liberty already activated historically (e.g. Tanenbaum 906001).
+// Package-level VaultManagerV2 is a test/stub address only. Live ChainConfig
+// must leave VaultManagerV2 zero until the real UUPS proxy is known, then set
+// both VaultManagerV2 and VaultMigrationBlock together. CheckConfigForkOrder
+// rejects scheduling migration to this stub. Do not couple migration to
+// LibertyBlock on networks where Liberty already activated historically
+// (e.g. Tanenbaum 906001).
 var (
 	VaultManagerNexusOld = common.HexToAddress("0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1")
 	// Deprecated: use VaultManagerNexusOld.
 	VaultManagerOld = VaultManagerNexusOld
 	VaultManager    = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
-	// Default stub; prefer ChainConfig.VaultManagerV2 for live networks.
+	// Stub for unit tests only — never schedule live VaultMigrationBlock to this.
 	VaultManagerV2 = common.HexToAddress("0x1111111111111111111111111111111111111111")
 )

--- a/params/nexus.go
+++ b/params/nexus.go
@@ -14,7 +14,9 @@ import (
 // where Liberty already activated historically (e.g. Tanenbaum 906001).
 var (
 	VaultManagerNexusOld = common.HexToAddress("0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1")
-	VaultManager         = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
+	// Deprecated: use VaultManagerNexusOld.
+	VaultManagerOld = VaultManagerNexusOld
+	VaultManager    = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
 	// Stub until replacement vault proxy is deployed at this address.
 	VaultManagerV2 = common.HexToAddress("0x1111111111111111111111111111111111111111")
 )

--- a/params/nexus.go
+++ b/params/nexus.go
@@ -1,19 +1,3 @@
-// Copyright 2016 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
 package params
 
 import (
@@ -23,13 +7,14 @@ import (
 // Vault manager addresses for Syscoin NEVM bridge cutovers.
 //
 // Nexus (activated): VaultManagerNexusOld → VaultManager
-// Liberty (at LibertyBlock): VaultManager → VaultManagerV2
+// Bridge V2 (at VaultMigrationBlock): VaultManager → VaultManagerV2
 //
-// Replace VaultManagerV2 with the deployed replacement vault before mainnet
-// LibertyBlock is set. Tanenbaum keeps LibertyBlock=906001 and must resync.
+// Replace VaultManagerV2 with the deployed replacement vault proxy before
+// setting VaultMigrationBlock. Do not couple this to LibertyBlock on networks
+// where Liberty already activated historically (e.g. Tanenbaum 906001).
 var (
 	VaultManagerNexusOld = common.HexToAddress("0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1")
 	VaultManager         = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
-	// Stub until replacement vault is deployed at this address.
+	// Stub until replacement vault proxy is deployed at this address.
 	VaultManagerV2 = common.HexToAddress("0x1111111111111111111111111111111111111111")
 )

--- a/params/nexus.go
+++ b/params/nexus.go
@@ -9,14 +9,16 @@ import (
 // Nexus (activated): VaultManagerNexusOld → VaultManager
 // Bridge V2 (at VaultMigrationBlock): VaultManager → VaultManagerV2
 //
-// Replace VaultManagerV2 with the deployed replacement vault proxy before
-// setting VaultMigrationBlock. Do not couple this to LibertyBlock on networks
-// where Liberty already activated historically (e.g. Tanenbaum 906001).
+// Package-level VaultManagerV2 is the default stub used by tests and as the
+// initial ChainConfig.VaultManagerV2 for each network. Replace the per-network
+// ChainConfig field with the deployed UUPS vault proxy before setting that
+// network's VaultMigrationBlock. Do not couple migration to LibertyBlock on
+// networks where Liberty already activated historically (e.g. Tanenbaum 906001).
 var (
 	VaultManagerNexusOld = common.HexToAddress("0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1")
 	// Deprecated: use VaultManagerNexusOld.
 	VaultManagerOld = VaultManagerNexusOld
 	VaultManager    = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
-	// Stub until replacement vault proxy is deployed at this address.
+	// Default stub; prefer ChainConfig.VaultManagerV2 for live networks.
 	VaultManagerV2 = common.HexToAddress("0x1111111111111111111111111111111111111111")
 )

--- a/params/nexus.go
+++ b/params/nexus.go
@@ -19,5 +19,17 @@ package params
 import (
 	"github.com/ethereum/go-ethereum/common"
 )
-var VaultManager = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
-var VaultManagerOld = common.HexToAddress("0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1")
+
+// Vault manager addresses for Syscoin NEVM bridge cutovers.
+//
+// Nexus (activated): VaultManagerNexusOld → VaultManager
+// Liberty (at LibertyBlock): VaultManager → VaultManagerV2
+//
+// Replace VaultManagerV2 with the deployed replacement vault before mainnet
+// LibertyBlock is set. Tanenbaum keeps LibertyBlock=906001 and must resync.
+var (
+	VaultManagerNexusOld = common.HexToAddress("0xA738a563F9ecb55e0b2245D1e9E380f0fE455ea1")
+	VaultManager         = common.HexToAddress("0x7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f")
+	// Stub until replacement vault is deployed at this address.
+	VaultManagerV2 = common.HexToAddress("0x1111111111111111111111111111111111111111")
+)


### PR DESCRIPTION
## Summary
- Migrate vault SYS at dedicated future `VaultMigrationBlock` (not historical `LibertyBlock`), via add-then-zero; zero-balance is an exact no-op
- Applied in `StateProcessor`, miner, chain makers, and `t8n`
- `VaultManagerV2` is **per-network** on `ChainConfig` (Tanenbaum/mainnet may differ); migration fork rejected if address unset or before Nexus
- Package `params.VaultManagerV2` remains the default stub for tests / initial config

## Cutover alignment
```
Geth F = VaultMigrationBlock
Relay F = minimumNEVMBlockNumber
Core H = nBridgeV2StartBlock
F = H - nNEVMStartBlock + 1
ChainConfig.VaultManagerV2 == deployed vault proxy == Core vchSyscoinVaultManager
```

## Test plan
- [x] `go test ./consensus/misc/ ./params/`
- [ ] Set per-network `VaultManagerV2` + `VaultMigrationBlock=F` after proxy deploy
- [ ] Confirm old vault balance is zero immediately after block `F`
