### PR TITLE
Schedule Tanenbaum Bridge V2 migration

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -121,11 +121,9 @@ var (
 		//ShanghaiTime:        newUint64(1675118284),
 		NexusBlock:          big.NewInt(665001),
 		LibertyBlock: big.NewInt(906001), // opcode fork only; already historical
-		// Intentionally nil until Bridge V2 cutover: a past LibertyBlock must not
-		// migrate vault balances. Set to future NEVM height F when the V2 proxy
-		// is deployed (paired with Core nBridgeV2StartBlock).
-		VaultMigrationBlock: nil,
-		// VaultManagerV2 left zero until the real proxy address is set with F.
+		// Bridge V2 cutover F, paired with Core testnet H=1786999.
+		VaultMigrationBlock: big.NewInt(947000),
+		VaultManagerV2:      common.HexToAddress("0x28bD37C0926575f2568ea8f297c0745EF16174Ab"),
 		LondonBlock:         big.NewInt(1),
 		//CancunTime:          newUint64(1675118284),
 		TerminalTotalDifficulty: big.NewInt(1),

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -50,6 +50,24 @@ func TestCheckConfigForkOrderVaultMigration(t *testing.T) {
 	}
 }
 
+func TestTanenbaumVaultMigrationConfig(t *testing.T) {
+	const expectedMigrationBlock int64 = 947000
+	expectedVault := common.HexToAddress("0x28bD37C0926575f2568ea8f297c0745EF16174Ab")
+
+	if TanenbaumChainConfig.VaultMigrationBlock == nil ||
+		TanenbaumChainConfig.VaultMigrationBlock.Cmp(big.NewInt(expectedMigrationBlock)) != 0 {
+		t.Fatalf("VaultMigrationBlock=%v want %d",
+			TanenbaumChainConfig.VaultMigrationBlock, expectedMigrationBlock)
+	}
+	if TanenbaumChainConfig.VaultManagerV2 != expectedVault {
+		t.Fatalf("VaultManagerV2=%s want %s",
+			TanenbaumChainConfig.VaultManagerV2, expectedVault)
+	}
+	if err := TanenbaumChainConfig.CheckConfigForkOrder(); err != nil {
+		t.Fatalf("Tanenbaum bridge V2 config rejected: %v", err)
+	}
+}
+
 func TestCheckCompatible(t *testing.T) {
 	type test struct {
 		stored, new   *ChainConfig


### PR DESCRIPTION
## Summary

- schedule the Tanenbaum Bridge V2 balance migration at NEVM block `947000`
- set the deployed V2 vault proxy to `0x28bD37C0926575f2568ea8f297c0745EF16174Ab`
- add a parameter regression that validates the address, activation block, and fork ordering

## Coordination

This NEVM cutover `F=947000` pairs with Syscoin Core testnet height `H=1786999` using `F = H - 840000 + 1`.

Companion Core PR: https://github.com/syscoin/syscoin/pull/605

## Validation

- verified the deployment artifact against live Tanenbaum RPC at height `945905`
- verified both proxy implementations, relay-to-vault binding, relay minimum block `947000`, SYS GUID `123456`, initial asset count `11`, and paused start state
- confirmed the existing TokenFreeze topic hash remains correct
- `git diff --check`

Per release workflow, static Linux Syscoin/geth builds will be produced on the designated server after both parameter PRs merge.