### PR TITLE
fix(nevm): bind status to exact Syscoin pair

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -43,6 +44,30 @@ func (bc *BlockChain) CurrentHeader() *types.Header {
 // block is retrieved from the blockchain's internal cache.
 func (bc *BlockChain) CurrentBlock() *types.Header {
 	return bc.currentBlock.Load()
+}
+
+// SYSCOIN: CurrentSyscoinPair returns one chain-mutex-consistent NEVM
+// height/Syscoin hash pair. Reading these separately can combine equal-height
+// reorg branches.
+func (bc *BlockChain) CurrentSyscoinPair() (uint64, []byte, bool) {
+	if !bc.chainmu.TryLock() {
+		return 0, nil, false
+	}
+	defer bc.chainmu.Unlock()
+
+	head := bc.currentBlock.Load()
+	if head == nil {
+		return 0, nil, false
+	}
+	number := head.Number.Uint64()
+	if number == 0 {
+		return 0, nil, true
+	}
+	sysHash := bc.hc.ReadSYSHash(number)
+	if len(sysHash) != common.HashLength {
+		return number, nil, false
+	}
+	return number, bytes.Clone(sysHash), true
 }
 
 // CurrentSnapBlock retrieves the current snap-sync head block of the canonical

--- a/eth/nevm_pair_test.go
+++ b/eth/nevm_pair_test.go
@@ -89,6 +89,11 @@ func TestDuplicateNEVMConnectRejectsUnpairedReplay(t *testing.T) {
 	if got := eth.blockchain.ReadSYSHash(1); !bytes.Equal(got, sysB1) {
 		t.Fatalf("SYSHash(1)=%x want %x", got, sysB1)
 	}
+	status := &ZMQRep{eth: eth}
+	count, pairedHash, ok := status.currentNEVMBlockInfo()
+	if !ok || count != 1 || pairedHash != encodeSyscoinDisplayHash(sysB1) {
+		t.Fatalf("paired status got ok=%v count=%d hash=%s", ok, count, pairedHash)
+	}
 
 	// Same NEVM block, different Core pairing — must not be a successful no-op.
 	if err := eth.AddBlock(makeNEVMConnect(e1, sysB2)); err == nil {
@@ -121,6 +126,10 @@ func TestDuplicateNEVMConnectRejectsUnpairedReplay(t *testing.T) {
 	}
 	if got := eth.blockchain.ReadSYSHash(1); len(got) != 0 {
 		t.Fatalf("SYSHash(1) left after matched disconnect: %x", got)
+	}
+	count, pairedHash, ok = status.currentNEVMBlockInfo()
+	if !ok || count != 0 || pairedHash != encodeSyscoinDisplayHash(nil) {
+		t.Fatalf("genesis status got ok=%v count=%d hash=%s", ok, count, pairedHash)
 	}
 }
 

--- a/eth/zmqpubsub.go
+++ b/eth/zmqpubsub.go
@@ -19,6 +19,7 @@ package eth
 
 import (
 	"context"
+	"encoding/hex"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -27,30 +28,46 @@ import (
 	"github.com/go-zeromq/zmq4"
 )
 
+func encodeSyscoinDisplayHash(serializedHash []byte) string {
+	// SYSCOIN: The pairing DB stores uint256's 32 serialized little-endian
+	// bytes. Status uses the conventional display order consumed by SetHex.
+	display := make([]byte, 32)
+	if len(serializedHash) == len(display) {
+		for i := range serializedHash {
+			display[len(display)-1-i] = serializedHash[i]
+		}
+	}
+	return hex.EncodeToString(display)
+}
+
+func (zmq *ZMQRep) currentNEVMBlockInfo() (uint64, string, bool) {
+	count, sysHash, ok := zmq.eth.blockchain.CurrentSyscoinPair()
+	return count, encodeSyscoinDisplayHash(sysHash), ok
+}
+
 type ZMQRep struct {
-	NEVMPubEP   string
-	eth         *Ethereum
-	rep         zmq4.Socket
-	inited      bool
-	ctx         context.Context
-	cancel      context.CancelFunc
+	NEVMPubEP string
+	eth       *Ethereum
+	rep       zmq4.Socket
+	inited    bool
+	ctx       context.Context
+	cancel    context.CancelFunc
 }
 
 func (zmq *ZMQRep) Close() {
-    if !zmq.inited {
-        return
-    }
-    zmq.inited = false
+	if !zmq.inited {
+		return
+	}
+	zmq.inited = false
 
-    zmq.cancel()
+	zmq.cancel()
 
-    if err := zmq.rep.Close(); err != nil {
-        log.Error("ZMQ socket close error", "err", err)
-    } else {
-        log.Info("ZMQ socket closed successfully")
-    }
+	if err := zmq.rep.Close(); err != nil {
+		log.Error("ZMQ socket close error", "err", err)
+	} else {
+		log.Info("ZMQ socket closed successfully")
+	}
 }
-
 
 func (zmq *ZMQRep) InitZMQListener() error {
 	err := zmq.rep.Listen(zmq.NEVMPubEP)
@@ -95,7 +112,7 @@ func (zmq *ZMQRep) InitZMQListener() error {
 					msgSend := zmq4.NewMsgFrom([]byte("nevmcomms"), []byte("ack"))
 					if err := zmq.rep.SendMulti(msgSend); err != nil {
 						log.Error("ZMQ send error", "topic", strTopic, "err", err)
-					}					
+					}
 				} else if strTopic == "nevmconnect" {
 					result := "connected"
 					var nevmBlockConnect types.NEVMBlockConnect
@@ -113,7 +130,7 @@ func (zmq *ZMQRep) InitZMQListener() error {
 					msgSend := zmq4.NewMsgFrom([]byte("nevmconnect"), []byte(result))
 					if err := zmq.rep.SendMulti(msgSend); err != nil {
 						log.Error("ZMQ send error", "topic", strTopic, "err", err)
-					}					
+					}
 				} else if strTopic == "nevmdisconnect" {
 					result := "disconnected"
 					var nevmBlockDisconnect types.NEVMBlockDisconnect
@@ -131,10 +148,10 @@ func (zmq *ZMQRep) InitZMQListener() error {
 					msgSend := zmq4.NewMsgFrom([]byte("nevmdisconnect"), []byte(result))
 					if err := zmq.rep.SendMulti(msgSend); err != nil {
 						log.Error("ZMQ send error", "topic", strTopic, "err", err)
-					}	
+					}
 				} else if strTopic == "nevmblock" {
 					var nevmBlockConnectBytes []byte
-				
+
 					block := zmq.eth.CreateBlock()
 					if block == nil {
 						log.Error("createBlockSub", "err", "block is nil")
@@ -148,20 +165,28 @@ func (zmq *ZMQRep) InitZMQListener() error {
 							nevmBlockConnectBytes = []byte{} // explicitly empty if serialization fails
 						}
 					}
-				
+
 					msgSend := zmq4.NewMsgFrom([]byte("nevmblock"), nevmBlockConnectBytes)
 					if err := zmq.rep.SendMulti(msgSend); err != nil {
 						log.Error("ZMQ send error", "topic", strTopic, "err", err)
 					}
-				
+
 					// explicitly clear bytes after send (optional, helps GC)
 					nevmBlockConnectBytes = nil
 				} else if strTopic == "nevmblockinfo" {
-					str := strconv.FormatUint(zmq.eth.blockchain.CurrentBlock().Number.Uint64(), 10)
-					msgSend := zmq4.NewMsgFrom([]byte("nevmblockinfo"), []byte(str))
+					current, lastSysHash, ok := zmq.currentNEVMBlockInfo()
+					count := strconv.FormatUint(current, 10)
+					if !ok {
+						// A non-numeric count makes the Core side fail closed instead
+						// of accepting a torn or unpaired status snapshot.
+						count = "unavailable"
+					}
+					// SYSCOIN: Count alone cannot distinguish equal-height Syscoin
+					// forks after a crash. Return the exact paired branch tip atomically.
+					msgSend := zmq4.NewMsgFrom([]byte("nevmblockinfo"), []byte(count), []byte(lastSysHash))
 					if err := zmq.rep.SendMulti(msgSend); err != nil {
 						log.Error("ZMQ send error", "topic", strTopic, "err", err)
-					}	
+					}
 				} else {
 					log.Error("Unknown ZMQ request topic", "topic", strTopic)
 					msgSend := zmq4.NewMsgFrom([]byte(strTopic), []byte("unknown-topic"))
@@ -179,13 +204,12 @@ func (zmq *ZMQRep) InitZMQListener() error {
 func NewZMQRep(stackIn *node.Node, ethIn *Ethereum, NEVMPubEPIn string) *ZMQRep {
 	ctx, cancel := context.WithCancel(context.Background())
 	zmq := &ZMQRep{
-		NEVMPubEP:       NEVMPubEPIn,
-		eth:         ethIn,
-		rep:         zmq4.NewRep(ctx),
-		ctx:         ctx,
-		cancel:      cancel,
+		NEVMPubEP: NEVMPubEPIn,
+		eth:       ethIn,
+		rep:       zmq4.NewRep(ctx),
+		ctx:       ctx,
+		cancel:    cancel,
 	}
 	log.Info("zmq Init")
 	return zmq
 }
-

--- a/eth/zmqpubsub_test.go
+++ b/eth/zmqpubsub_test.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package eth
+
+import "testing"
+
+// SYSCOIN: Core and NEVM exchange uint256 hashes in display order.
+func TestEncodeSyscoinDisplayHash(t *testing.T) {
+	serialized := make([]byte, 32)
+	serialized[0] = 0x01
+	serialized[31] = 0xfe
+	const expected = "fe00000000000000000000000000000000000000000000000000000000000001"
+	if got := encodeSyscoinDisplayHash(serialized); got != expected {
+		t.Fatalf("wrong Syscoin display hash: got %s want %s", got, expected)
+	}
+
+	const zero = "0000000000000000000000000000000000000000000000000000000000000000"
+	if got := encodeSyscoinDisplayHash(nil); got != zero {
+		t.Fatalf("missing pairing must fail closed as zero: got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add an atomic `CurrentSyscoinPair` snapshot under the canonical-chain mutex
- extend `nevmblockinfo` from height-only status to `topic + height + exact Syscoin hash`
- preserve Syscoin uint256 display byte order and fail closed while the chain pair is unavailable
- cover paired connect/disconnect state and non-palindromic hash encoding

## Why

A height-only NEVM status cannot distinguish two Syscoin branches at the same height. Reading the NEVM head and paired Syscoin hash independently can also produce a torn snapshot during a concurrent reorg. Syscoin Core's hardened replay logic needs one exact height/hash pair before it can decide whether Geth is synchronized with the active Syscoin branch.

## Compatibility

This is a paired protocol change with the Syscoin Core post-quantum ChainLock/BTCC draft. The matching Core consumer requires exactly three multipart frames. The bundled Syscoin `sysgeth` binary is intentionally **not** updated in this source PR; that reproducible binary refresh will follow after both source PRs merge.

## Validation

- `GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off go test ./eth ./core -count=1`
- `gofmt -d core/blockchain_reader.go eth/nevm_pair_test.go eth/zmqpubsub.go eth/zmqpubsub_test.go`
- `git diff --check`
